### PR TITLE
feat: add default index template and schema to document

### DIFF
--- a/coco.yml
+++ b/coco.yml
@@ -19,6 +19,32 @@ elastic:
     enabled: true
   orm:
     enabled: true
+    index_prefix: "coco_"
+    override_exists_template: true
+    templates:
+      "coco-search": |
+        {
+          "order": 10,
+          "index_patterns": [
+            "coco_*"
+          ],
+          "settings": {
+            "index": {
+              "analysis": {
+                "analyzer": {
+                  "suggest_text_search": {
+                    "filter": [
+                     "lowercase",
+                      "word_delimiter"
+                    ],
+                    "tokenizer": "classic"
+                  }
+                }
+              }
+            }
+          },
+          "mappings": {}
+        }
 
 elasticsearch:
   - name: prod

--- a/modules/common/document.go
+++ b/modules/common/document.go
@@ -11,29 +11,33 @@ import (
 
 type Document struct {
 	orm.ORMObjectBase                  // Embedding ORM base for persistence-related fields
-	Source        string            `json:"source,omitempty"`     // Source of the document (e.g., "github", "google_drive", "dropbox")
-	Category      string            `json:"category,omitempty"`   // Primary category of the document (e.g., "report", "article")
-	Categories    []string          `json:"categories,omitempty"` // Full hierarchy of categories, useful for detailed classification
-	Cover         string            `json:"cover,omitempty"`      // Cover image URL, if applicable
-	Title         string            `json:"title,omitempty"`      // Document title
-	Summary       string            `json:"summary,omitempty"`    // Brief summary or description of the document
-	Type          string            `json:"type,omitempty"`       // Document type, such as PDF, Docx, etc.
-	Lang          string            `json:"lang,omitempty"`       // Language code (e.g., "en", "fr")
-	Content       string            `json:"content,omitempty"`    // Document content for full-text indexing
-	Thumbnail     string            `json:"thumbnail,omitempty"`  // Thumbnail image URL, for preview purposes
-	Owner         string            `json:"owner,omitempty"`      // Document author or owner
-	Tags          []string          `json:"tags,omitempty"`       // Tags or keywords associated with the document, for easier retrieval
-	URL           string            `json:"url,omitempty"`        // Direct link to the document, if available
-	Size          int               `json:"size,omitempty"`       // File size in bytes, if applicable
+	Source        string            `json:"source,omitempty" elastic_mapping:"source:{type:keyword,copy_to:search_text}"`     // Source of the document (e.g., "github", "google_drive", "dropbox")
+	Category      string            `json:"category,omitempty" elastic_mapping:"category:{type:keyword,copy_to:search_text}"`   // Primary category of the document (e.g., "report", "article")
+	Categories    []string          `json:"categories,omitempty" elastic_mapping:"categories:{type:keyword,copy_to:search_text}"` // Full hierarchy of categories, useful for detailed classification
+	Cover         string            `json:"cover,omitempty" elastic_mapping:"cover:{enabled:false}"`      // Cover image URL, if applicable
+	Title         string            `json:"title,omitempty" elastic_mapping:"title:{type:keyword,copy_to:search_text}"`      // Document title
+	Summary       string            `json:"summary,omitempty" elastic_mapping:"summary:{type:text}"`    // Brief summary or description of the document
+	Type          string            `json:"type,omitempty" elastic_mapping:"type:{type:keyword,copy_to:search_text}"`       // Document type, such as PDF, Docx, etc.
+	Lang          string            `json:"lang,omitempty" elastic_mapping:"lang:{type:keyword,copy_to:search_text}"`       // Language code (e.g., "en", "fr")
+	Content       string            `json:"content,omitempty" elastic_mapping:"content:{type:text}"`    // Document content for full-text indexing
+	Thumbnail     string            `json:"thumbnail,omitempty" elastic_mapping:"thumbnail:{enabled:false}"`  // Thumbnail image URL, for preview purposes
+	Owner         string            `json:"owner,omitempty" elastic_mapping:"owner:{type:keyword,copy_to:search_text}"`      // Document author or owner
+	Tags          []string          `json:"tags,omitempty" elastic_mapping:"tags:{type:keyword,copy_to:search_text}"`       // Tags or keywords associated with the document, for easier retrieval
+	URL           string            `json:"url,omitempty" elastic_mapping:"url:{enabled:false}"`        // Direct link to the document, if available
+	Size          int               `json:"size,omitempty" elastic_mapping:"size:{type:long}"`       // File size in bytes, if applicable
 	Metadata      map[string]string `json:"metadata,omitempty"`   // Additional source-specific metadata (e.g., file version, permissions)
 	LastUpdatedBy struct {
-		UserInfo  UserInfo   `json:"user,omitempty"`      // Information about the last user who updated the document
+		UserInfo  UserInfo   `json:"user,omitempty" elastic_mapping:"user:{type:object}"`      // Information about the last user who updated the document
 		UpdatedAt *time.Time `json:"timestamp,omitempty"` // Timestamp of the last update
-	} `json:"last_updated_by,omitempty"`                    // Struct containing last update information
+	} `json:"last_updated_by,omitempty" elastic_mapping:"last_updated_by:{type:object}"`                    // Struct containing last update information
+
+
+	//
+	SearchText string `json:"-" elastic_mapping:"search_text:{type:text,index_prefixes:{},index_phrases:true, analyzer:suggest_text_search }"`
 }
 
 // UserInfo represents information about a user in relation to document edits or ownership.
 type UserInfo struct {
-	UserName string `json:"username,omitempty"` // Username of the user
-	UserID   string `json:"userid,omitempty"`   // Unique identifier for the user
+	UserName string `json:"username,omitempty" elastic_mapping:"username:{type:keyword,copy_to:search_text}"` // Username of the user
+	UserID   string `json:"userid,omitempty" elastic_mapping:"userid:{type:keyword,copy_to:search_text}"`   // Unique identifier for the user
 }

--- a/modules/search/init.go
+++ b/modules/search/init.go
@@ -14,6 +14,7 @@ type APIHandler struct {
 
 func init() {
 	handler := APIHandler{}
+
 	api.HandleAPIMethod(api.POST, "/query/_suggest", handler.suggest)
 	api.HandleAPIMethod(api.POST, "/query/_recommend", handler.recommend)
 	api.HandleAPIMethod(api.POST, "/query/_search", handler.search)


### PR DESCRIPTION
This pull request includes significant updates to the Elasticsearch configuration and the document structure in the codebase, as well as a minor addition to the API handler initialization.

### Elasticsearch Configuration Enhancements:

* [`coco.yml`](diffhunk://#diff-461bb31f066abaf4260e1409e70068530cccf332d5b44ce8174eb39cbc253e23R22-R47): Added an index prefix, template override, and a detailed template configuration for the `coco-search` index, including settings for analysis and mappings.

### Document Structure Updates:

* [`modules/common/document.go`](diffhunk://#diff-85818a05e195a012b8aec7cf396c94651e47a53f2fa13a05c3ee47841da25db3L14-R42): Added `elastic_mapping` tags to the `Document` struct fields for better Elasticsearch integration, including mapping types and indexing options. Introduced a new `SearchText` field for enhanced search capabilities.

### API Handler Initialization:

* [`modules/search/init.go`](diffhunk://#diff-ebd2edd25288345f08d23d4c4e6c96e2aaaeb92569ec04faa7c4188aae0a74deR17): Added a new line to initialize the `APIHandler` struct before setting up API methods for query suggestions, recommendations, and searches.