### PR TITLE
refactor: refactoring connectors

### DIFF
--- a/docs/content.en/docs/references/assistant.md
+++ b/docs/content.en/docs/references/assistant.md
@@ -88,7 +88,7 @@ curl  -H'WEBSOCKET-SESSION-ID: csk88l3q50kb4hr5unn0'  -H 'Content-Type: applicat
 
 Tips: `WEBSOCKET-SESSION-ID` should be replaced with the actual WebSocket session ID. You will receive a message each time you connect to the Coco AI WebSocket server. For example: `ws://localhost:2900/ws` or `wss://localhost:2900/ws` if TLS is enabled.
 
-![](/img/websocket-on-connect.jpg?raw=true)
+{{% load-img "/img/websocket-on-connect.jpg?raw=true" "WebSocket ID" %}}
 
 ### Close a Chat Session
 

--- a/docs/content.en/docs/references/connectors/google_drive.md
+++ b/docs/content.en/docs/references/connectors/google_drive.md
@@ -56,14 +56,13 @@ To use the Google Drive Connector, follow these steps to obtain your token:
 
 1. Set the **Authorized Redirect URIs** as shown in the following screenshot:
 
-   ![Authorized Redirect URIs](/img/google_drive_token.jpg)
+{{% load-img "/img/google_drive_token.jpg" "Authorized Redirect URIs" %}}
 
 2. The Google Drive connector uses `/connector/google_drive/oauth_redirect` as the callback URL to receive authorization responses.
 
 3. Once the token is successfully obtained, download the `credentials.json` file.
 
-   ![credentials.json](/img/download_google_drive_token.png)
-
+{{% load-img "/img/download_google_drive_token.png" "credentials.json" %}}
 
 ### Important Notes:
 - If you deploy the **coco-server** in your production environment, ensure you:

--- a/plugins/connectors/google_drive/api.go
+++ b/plugins/connectors/google_drive/api.go
@@ -113,11 +113,6 @@ func (h *Plugin) oAuthRedirect(w http.ResponseWriter, req *http.Request, _ httpr
 		panic(err)
 	}
 
-	//err = h.saveToken(tenantID, userID, token)
-	//if err != nil {
-	//	panic(err)
-	//}
-
 	newRedirectUrl := util.JoinPath(redirectPath, "?source=google_drive")
 	h.Redirect(w, req, newRedirectUrl)
 }

--- a/plugins/connectors/google_drive/files.go
+++ b/plugins/connectors/google_drive/files.go
@@ -30,12 +30,40 @@ func getIcon(fileType string) string {
 		return "presentation"
 	case "application/vnd.google-apps.spreadsheet":
 		return "spreadsheet"
+	case "application/vnd.google-apps.drawing":
+		return "drawing"
+	case "application/vnd.google-apps.folder":
+		return "folder"
+	case "application/vnd.google-apps.fusiontable":
+		return "fusiontable"
+	case "application/vnd.google-apps.jam":
+		return "jam"
+	case "application/vnd.google-apps.map":
+		return "map"
+	case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": // MS Excel
+		return "ms_excel"
+	case "application/vnd.openxmlformats-officedocument.presentationml.presentation": // MS PowerPoint
+		return "ms_powerpoint"
+	case "application/vnd.openxmlformats-officedocument.wordprocessingml.document": // MS Word
+		return "ms_word"
+	case "application/vnd.google-apps.script":
+		return "script"
+	case "application/vnd.google-apps.site":
+		return "site"
+	case "application/vnd.google-apps.video":
+		return "video"
+	case "application/zip":
+		return "zip"
+	case "image/jpeg", "image/png", "image/gif", "image/tiff", "image/bmp": // Image formats
+		return "photo"
+	case "audio/mpeg", "audio/wav", "audio/mp3", "audio/ogg": // Audio formats
+		return "audio"
 	default:
-		return "default" // default fallback
+		return "default" // Default fallback
 	}
 }
 
-func (this *Plugin) startIndexingFiles(tenantID, userID string, tok *oauth2.Token) {
+func (this *Plugin) startIndexingFiles(tenantID, userID, datasourceID string, tok *oauth2.Token) {
 	var filesProcessed = 0
 	defer func() {
 		if !global.Env().IsDebug {
@@ -68,7 +96,7 @@ func (this *Plugin) startIndexingFiles(tenantID, userID string, tok *oauth2.Toke
 	var query string
 
 	//get last access time from kv
-	lastModifiedTimeStr, _ := this.getLastModifiedTime(tenantID, userID)
+	lastModifiedTimeStr, _ := this.getLastModifiedTime(tenantID, userID, datasourceID)
 
 	log.Tracef("get last modified time: %v", lastModifiedTimeStr)
 
@@ -216,7 +244,7 @@ func (this *Plugin) startIndexingFiles(tenantID, userID string, tok *oauth2.Toke
 		if lastModifyTime != nil {
 			// Save the lastModifyTime (for example, in a KV store or file)
 			lastModifiedTimeStr = lastModifyTime.Format(time.RFC3339Nano)
-			err := this.saveLastModifiedTime(tenantID, userID, lastModifiedTimeStr)
+			err := this.saveLastModifiedTime(tenantID, userID, lastModifiedTimeStr, datasourceID)
 			if err != nil {
 				panic(err)
 			}

--- a/plugins/connectors/google_drive/plugin.go
+++ b/plugins/connectors/google_drive/plugin.go
@@ -185,7 +185,7 @@ func (this *Plugin) fetch_google_drive(connector *common.Connector, datasource *
 			log.Warnf("skip invalid google_drive token: %v", tok)
 		} else {
 			log.Debug("start processing google drive files")
-			this.startIndexingFiles(tenantID, userID, &tok)
+			this.startIndexingFiles(tenantID, userID, datasource.ID, &tok)
 			log.Debug("finished process google drive files")
 		}
 	}

--- a/plugins/connectors/yuque/collect.go
+++ b/plugins/connectors/yuque/collect.go
@@ -32,7 +32,7 @@ func get(path, token string) *util.Result {
 }
 
 func (this *Plugin) getIconKey(category, iconType string) string {
-	return fmt.Sprintf("%v_%v", strings.TrimSpace(strings.ToLower(category)), strings.TrimSpace(strings.ToLower(iconType)))
+	return strings.TrimSpace(strings.ToLower(iconType))
 }
 
 func (this *Plugin) cleanupIconName(name string) string {


### PR DESCRIPTION
## What does this PR do


This pull request includes significant changes to the `plugins/connectors/google_drive` plugin, focusing on enhancing the handling of multiple data sources and improving file type recognition. The most important changes include updating function signatures to include `datasourceID`, modifying the `getIcon` function to support additional file types, and commenting out unused code.

Enhancements to data source handling:

* [`plugins/connectors/google_drive/api.go`](diffhunk://#diff-f3b2e174f74b46eae7e8a3d185d24e81e04846268b1561c78312b774123bd14bL84-R85): Updated function signatures to include `datasourceID` and modified the `getTenantKey` function to accommodate this new parameter. [[1]](diffhunk://#diff-f3b2e174f74b46eae7e8a3d185d24e81e04846268b1561c78312b774123bd14bL84-R85) [[2]](diffhunk://#diff-f3b2e174f74b46eae7e8a3d185d24e81e04846268b1561c78312b774123bd14bL116-R135) [[3]](diffhunk://#diff-f3b2e174f74b46eae7e8a3d185d24e81e04846268b1561c78312b774123bd14bL147-L187)
* [`plugins/connectors/google_drive/files.go`](diffhunk://#diff-998d146d9dbe5ae2861beb0339ffbf04fcef3f67252b1248d2a5d5e5c8af7a0dL71-R99): Updated the `startIndexingFiles` function and related calls to include `datasourceID`. [[1]](diffhunk://#diff-998d146d9dbe5ae2861beb0339ffbf04fcef3f67252b1248d2a5d5e5c8af7a0dL71-R99) [[2]](diffhunk://#diff-998d146d9dbe5ae2861beb0339ffbf04fcef3f67252b1248d2a5d5e5c8af7a0dL219-R247) [[3]](diffhunk://#diff-cb8fd14077b5b755f5dfa9b7fc7f5419e440a7d1467a5ca1fa35f22fe1c243f9L188-R188)

Improvements to file type recognition:

* [`plugins/connectors/google_drive/files.go`](diffhunk://#diff-998d146d9dbe5ae2861beb0339ffbf04fcef3f67252b1248d2a5d5e5c8af7a0dR33-R66): Enhanced the `getIcon` function to support additional Google Drive file types and common file formats.

Code cleanup:

* [`plugins/connectors/google_drive/api.go`](diffhunk://#diff-f3b2e174f74b46eae7e8a3d185d24e81e04846268b1561c78312b774123bd14bL84-R85): Commented out unused code related to `tenantID` and `userID` in the `oAuthRedirect` function. [[1]](diffhunk://#diff-f3b2e174f74b46eae7e8a3d185d24e81e04846268b1561c78312b774123bd14bL84-R85) [[2]](diffhunk://#diff-f3b2e174f74b46eae7e8a3d185d24e81e04846268b1561c78312b774123bd14bL116-R135)
* [`plugins/connectors/yuque/collect.go`](diffhunk://#diff-4be6baed1f7d4f2651bb71fdf04a79be5fcdc40693f9b40e3a1dd00877ea2acdL35-R35): Simplified the `getIconKey` function by removing the `category` parameter.] The commit messages are [semantic](https://www.conventionalcommits.org/)

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation