### PR TITLE
chore: remove redundant last category if it matches the document title

### DIFF
--- a/modules/common/document.go
+++ b/modules/common/document.go
@@ -5,6 +5,7 @@
 package common
 
 import (
+	"strings"
 	"time"
 )
 
@@ -54,6 +55,19 @@ type Document struct {
 
 	LastUpdatedBy *EditorInfo `json:"last_updated_by,omitempty" elastic_mapping:"last_updated_by:{type:object}"` // Struct containing last update information
 
+}
+
+func (document *Document) Cleanup() {
+	document.TrimLastDuplicatedCategory()
+}
+
+func (document *Document) TrimLastDuplicatedCategory() {
+	// Ensure RichCategories is not empty before accessing the last element
+	if len(document.RichCategories) > 0 &&
+		strings.TrimSpace(document.RichCategories[len(document.RichCategories)-1].Label) == strings.TrimSpace(document.Title) {
+		// Remove the last category if it matches the book's title (it's redundant)
+		document.RichCategories = document.RichCategories[:len(document.RichCategories)-1]
+	}
 }
 
 type EditorInfo struct {

--- a/plugins/connectors/yuque/collect.go
+++ b/plugins/connectors/yuque/collect.go
@@ -239,9 +239,12 @@ func (this *Plugin) collectBooks(connector *common.Connector, datasource *common
 				}
 
 				if !cfg.SkipIndexingBookToc {
+					// Check if the book's Table of Contents (ToC) exists in the map
 					if v, ok := bookTocMap[bookDetail.Book.Slug]; ok {
+						// Assign the ToC to the document's RichCategories
 						document.RichCategories = v
 					} else {
+						// Log a warning if the ToC information is missing
 						log.Debug("missing toc info:", bookDetail.Book.Slug, ",", bookDetail.Book.Name)
 					}
 				}
@@ -267,6 +270,8 @@ func (this *Plugin) collectBooks(connector *common.Connector, datasource *common
 
 				document.Created = &bookDetail.Book.CreatedAt
 				document.Updated = &bookDetail.Book.UpdatedAt
+
+				document.Cleanup()
 
 				this.save(document)
 			} else {
@@ -414,6 +419,8 @@ func (this *Plugin) collectDocDetails(connector *common.Connector, datasource *c
 
 		document.Created = &doc.Doc.CreatedAt
 		document.Updated = &doc.Doc.UpdatedAt
+
+		document.Cleanup()
 
 		this.save(document)
 	}


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation