### PR TITLE
feat: add field `SyncEnabled` to control datasource synchronization

### DIFF
--- a/modules/common/datasource.go
+++ b/modules/common/datasource.go
@@ -12,6 +12,8 @@ type DataSource struct {
 	Icon string `json:"icon,omitempty" elastic_mapping:"icon:{type:keyword}"` // Display name of this datasource
 
 	Connector ConnectorConfig `json:"connector,omitempty" elastic_mapping:"connector:{type:keyword}"`
+	// Whether synchronization is allowed
+	SyncEnabled bool `json:"sync_enabled" elastic_mapping:"sync_enabled:{type:keyword}"`
 }
 
 type ConnectorConfig struct {

--- a/modules/connector/datasource.go
+++ b/modules/connector/datasource.go
@@ -36,7 +36,10 @@ func (h *APIHandler) createDatasource(w http.ResponseWriter, req *http.Request, 
 			panic("invalid connector")
 		}
 
-		err = orm.Create(nil, obj)
+		ctx := orm.Context{
+			Refresh: "wait_for",
+		}
+		err = orm.Create(&ctx, obj)
 		if err != nil {
 			h.WriteError(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -67,7 +70,10 @@ func (h *APIHandler) deleteDatasource(w http.ResponseWriter, req *http.Request, 
 		return
 	}
 
-	err = orm.Delete(nil, &obj)
+	ctx := &orm.Context{
+		Refresh: "wait_for",
+	}
+	err = orm.Delete(ctx, &obj)
 	if err != nil {
 		h.WriteError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -148,7 +154,10 @@ func (h *APIHandler) updateDatasource(w http.ResponseWriter, req *http.Request, 
 	//protect
 	obj.ID = id
 	obj.Created = create
-	err = orm.Update(nil, &obj)
+	ctx := &orm.Context{
+		Refresh: "wait_for",
+	}
+	err = orm.Update(ctx, &obj)
 	if err != nil {
 		h.WriteError(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/modules/system/initialize.go
+++ b/modules/system/initialize.go
@@ -57,6 +57,7 @@ type SetupConfig struct {
 		Type         string `json:"type,omitempty"`
 		Endpoint     string `json:"endpoint,omitempty"`
 		DefaultModel string `json:"default_model,omitempty"`
+		Token        string `json:"token,omitempty"`
 	} `json:"llm,omitempty"`
 }
 
@@ -92,6 +93,7 @@ func (h *APIHandler) setupServer(w http.ResponseWriter, req *http.Request, ps ht
 		info.LLMConfig.Endpoint = input.LLM.Endpoint
 		info.LLMConfig.DefaultModel = input.LLM.DefaultModel
 		info.LLMConfig.Type = input.LLM.Type
+		info.LLMConfig.Token = input.LLM.Token
 	}
 
 	if input.Name != "" {

--- a/plugins/connectors/google_drive/plugin.go
+++ b/plugins/connectors/google_drive/plugin.go
@@ -122,7 +122,7 @@ func (this *Plugin) Start() error {
 
 				q := orm.Query{}
 				q.Size = this.PageSize //TODO
-				q.Conds = orm.And(orm.Eq("connector.id", connector.ID))
+				q.Conds = orm.And(orm.Eq("connector.id", connector.ID), orm.Eq("sync_enabled", true))
 				var results []common.DataSource
 				err, _ = orm.SearchWithJSONMapper(&results, &q)
 				if err != nil {

--- a/plugins/connectors/hugo_site/plugin.go
+++ b/plugins/connectors/hugo_site/plugin.go
@@ -88,7 +88,7 @@ func (this *Plugin) Start() error {
 
 				q := orm.Query{}
 				q.Size = this.PageSize
-				q.Conds = orm.And(orm.Eq("connector.id", connector.ID))
+				q.Conds = orm.And(orm.Eq("connector.id", connector.ID), orm.Eq("sync_enabled", true))
 				var results []common.DataSource
 
 				err, _ = orm.SearchWithJSONMapper(&results, &q)

--- a/plugins/connectors/notion/plugin.go
+++ b/plugins/connectors/notion/plugin.go
@@ -94,7 +94,7 @@ func (this *Plugin) Start() error {
 
 				q := orm.Query{}
 				q.Size = this.PageSize
-				q.Conds = orm.And(orm.Eq("connector.id", connector.ID))
+				q.Conds = orm.And(orm.Eq("connector.id", connector.ID), orm.Eq("sync_enabled", true))
 				var results []common.DataSource
 
 				err, _ = orm.SearchWithJSONMapper(&results, &q)

--- a/plugins/connectors/yuque/plugin.go
+++ b/plugins/connectors/yuque/plugin.go
@@ -79,7 +79,7 @@ func (this *Plugin) Start() error {
 
 				q := orm.Query{}
 				q.Size = this.PageSize
-				q.Conds = orm.And(orm.Eq("connector.id", connector.ID))
+				q.Conds = orm.And(orm.Eq("connector.id", connector.ID), orm.Eq("sync_enabled", true))
 				var results []common.DataSource
 
 				err, _ = orm.SearchWithJSONMapper(&results, &q)

--- a/web/src/locales/langs/en-us/page.ts
+++ b/web/src/locales/langs/en-us/page.ts
@@ -103,6 +103,7 @@ const page: App.I18n.Schema['translation']['page'] = {
         client_id: "Client ID",
         client_secret: "Client Secret",
         redirect_uri: "Redirect URI",
+        sync_enabled: "Sync Enabled",
       }
     }
   }

--- a/web/src/locales/langs/zh-cn/page.ts
+++ b/web/src/locales/langs/zh-cn/page.ts
@@ -103,6 +103,7 @@ const page: App.I18n.Schema['translation']['page'] = {
         client_id: "客户端 ID",
         client_secret: "客户端密钥",
         redirect_uri: "重定向 URI",
+        sync_enabled: "是否启用同步",
       }
     }
   }

--- a/web/src/pages/data-source/edit/[id].tsx
+++ b/web/src/pages/data-source/edit/[id].tsx
@@ -4,6 +4,7 @@ import {
   Form,
   Input,
   message,
+  Switch,
 } from 'antd';
 import type { FormProps } from 'antd';
 import {TypeList} from '@/components/datasource/type';
@@ -21,6 +22,8 @@ export function Component() {
     const sValues = {
       name: values.name,
       type: "connector",
+      enabled: values.enabled,
+      sync_enabled: values.sync_enabled,
       connector: {
         id: values.connector.id,
         config: {
@@ -75,6 +78,9 @@ export function Component() {
             </Form.Item>
             <Form.Item label={t('page.datasource.new.labels.data_sync')} name="sync_config">
              <DataSync/>
+            </Form.Item>
+            <Form.Item label={t('page.datasource.new.labels.sync_enabled')} name="sync_enabled">
+              <Switch />
             </Form.Item>
             <Form.Item label=" ">
               <Button type='primary' loading={loading}  htmlType="submit">{t('common.save')}</Button>

--- a/web/src/pages/data-source/list/index.tsx
+++ b/web/src/pages/data-source/list/index.tsx
@@ -111,17 +111,14 @@ export function Component() {
         return type.name
       },
     },
-    // {
-    //   dataIndex: 'sync_config.type',
-    //   width: 200,
-    //   title: t('page.datasource.columns.sync_policy')
-    // },
-    // {
-    //   dataIndex: 'latest_sync_time',
-    //   key: 'latest_sync_time',
-    //   title: t('page.datasource.columns.latest_sync_time'),
-    //   width: 200
-    // },
+    {
+      dataIndex: 'sync_enabled',
+      title: t('page.datasource.new.labels.sync_enabled'),
+      width: 200,
+      render: (value: boolean)=>{
+        return value ? t('common.yesOrNo.yes') : t('common.yesOrNo.no')
+      }
+    },
     // {
     //   dataIndex: 'sync_status',
     //   key: 'sync_status',

--- a/web/src/pages/data-source/new/index.tsx
+++ b/web/src/pages/data-source/new/index.tsx
@@ -4,6 +4,7 @@ import {
   Form,
   Input,
   message,
+  Switch,
 } from 'antd';
 import type { FormProps } from 'antd';
 import {TypeList} from '@/components/datasource/type';
@@ -25,6 +26,7 @@ export function Component() {
     const sValues = {
       name: values.name,
       type: "connector",
+      sync_enabled: values.sync_enabled,
       connector: {
         id: values.connector.id,
         config: {
@@ -74,6 +76,9 @@ export function Component() {
             </Form.Item>
             <Form.Item initialValue={{sync_type: "interval", interval: "60s"}} label={t('page.datasource.new.labels.data_sync')} name="sync_config">
              <DataSync/>
+            </Form.Item>
+            <Form.Item initialValue={true} label={t('page.datasource.new.labels.sync_enabled')} name="sync_enabled">
+              <Switch />
             </Form.Item>
             <Form.Item label=" ">
               <Button type='primary'  htmlType="submit">{t('common.save')}</Button>

--- a/web/src/types/api.d.ts
+++ b/web/src/types/api.d.ts
@@ -271,6 +271,8 @@ declare namespace Api {
       name: string;
       connector: Connector;
       sync_config: any;
+      enabled: boolean;
+      sync_enabled: boolean;
     }
   }
 }


### PR DESCRIPTION
## What does this PR do
This pull request includes several changes to add synchronization control for data sources and improve the handling of ORM contexts. The most important changes include adding a `SyncEnabled` field to the `DataSource` struct, updating ORM operations to use a context with a refresh policy, and adding UI elements to control synchronization settings.

### Synchronization control:

* [`modules/common/datasource.go`](diffhunk://#diff-90febfa38c364d2213123da5690c26e866036769c74600e76bebf47675efcf30R15-R16): Added a `SyncEnabled` field to the `DataSource` struct to indicate whether synchronization is allowed.
* `web/src/pages/data-source/edit/[id].tsx`, `web/src/pages/data-source/new/index.tsx`: Added a `Switch` component to the forms for creating and editing data sources to control the `sync_enabled` field. ([web/src/pages/data-source/edit/[id].tsxR7](diffhunk://#diff-0e1579d4c0b72eba356baa4f3023292d6fbbf3160cb09c17e04c4bcecdb57f9bR7), [web/src/pages/data-source/new/index.tsxR7](diffhunk://#diff-d20e9d2d3590087cb67cc4d1b8253a446875a9e0239ab449c7b29f7323de6c3fR7))
* `web/src/locales/langs/en-us/page.ts`, `web/src/locales/langs/zh-cn/page.ts`: Added translations for the `sync_enabled` label. [[1]](diffhunk://#diff-75b46bb6ff5551b15d45f213e647a5c4b3882be613ba82b94471dfdc27c24ad4R106) [[2]](diffhunk://#diff-798822d4178cb3745edd08d7e17722afd6e720a840be526ef652b5f2b611dcb6R106)

### ORM context handling:

* [`modules/connector/datasource.go`](diffhunk://#diff-9091070971f4757fa7060e0bbfa0a3cd15622d928e1aaa96aaaf636643b5457fL39-R42): Updated the `createDatasource`, `deleteDatasource`, and `updateDatasource` functions to use an `orm.Context` with a `Refresh` policy set to `wait_for`. [[1]](diffhunk://#diff-9091070971f4757fa7060e0bbfa0a3cd15622d928e1aaa96aaaf636643b5457fL39-R42) [[2]](diffhunk://#diff-9091070971f4757fa7060e0bbfa0a3cd15622d928e1aaa96aaaf636643b5457fL70-R76) [[3]](diffhunk://#diff-9091070971f4757fa7060e0bbfa0a3cd15622d928e1aaa96aaaf636643b5457fL151-R160)

### Plugin updates:

* `plugins/connectors/google_drive/plugin.go`, `plugins/connectors/hugo_site/plugin.go`, `plugins/connectors/notion/plugin.go`, `plugins/connectors/yuque/plugin.go`: Updated the `Start` methods to include a condition that checks if `sync_enabled` is true. [[1]](diffhunk://#diff-cb8fd14077b5b755f5dfa9b7fc7f5419e440a7d1467a5ca1fa35f22fe1c243f9L125-R125) [[2]](diffhunk://#diff-aac5e49f7b84bde5bae69cccd0412fe0c66a639b1350cf6adc578385617d762dL91-R91) [[3]](diffhunk://#diff-3117836c4ba3770641d16c2c991410d50ef99d65c22eaf3f30bb547bc8c90f9bL97-R97) [[4]](diffhunk://#diff-157d3b4cf38385cfea12676f6be7e0104e531076522faf3937ef46e27e1a952eL82-R82)

### Additional changes:

* [`modules/system/initialize.go`](diffhunk://#diff-b78129ce01dbbb7ab2977a3ad2996658721102529f8da3a87ddee1e363274d1bR60): Added a `Token` field to the `SetupConfig` struct and updated the `setupServer` function to handle this new field. [[1]](diffhunk://#diff-b78129ce01dbbb7ab2977a3ad2996658721102529f8da3a87ddee1e363274d1bR60) [[2]](diffhunk://#diff-b78129ce01dbbb7ab2977a3ad2996658721102529f8da3a87ddee1e363274d1bR96)
* [`web/src/pages/data-source/list/index.tsx`](diffhunk://#diff-5bf0eccc9387dc824769eb6e3268d6a1494462b466bd12eeecb3b30c548275e3L114-R121): Added a column to display the `sync_enabled` status in the data source list.
## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation