### PR TITLE
chore: update default proxy enabled to `false`

### DIFF
--- a/coco.yml
+++ b/coco.yml
@@ -355,7 +355,7 @@ pipeline:
 http_client:
   default:
     proxy:
-      enabled: true
+      enabled: false
       default_config:
         http_proxy: http://127.0.0.1:7890
         socket5_proxy: socks5://127.0.0.1:7890


### PR DESCRIPTION
## What does this PR do
This pull request includes a small change to the `coco.yml` file. The change disables the proxy by setting the `enabled` field to `false`.

* [`coco.yml`](diffhunk://#diff-461bb31f066abaf4260e1409e70068530cccf332d5b44ce8174eb39cbc253e23L358-R358): Disabled the proxy by setting `enabled` to `false` under `http_client.default.proxy`.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation