### PR TITLE
docs: upgrade to 0.2.1

### DIFF
--- a/docs/content.en/docs/getting-started/install.md
+++ b/docs/content.en/docs/getting-started/install.md
@@ -26,8 +26,8 @@ asciinema: true
 #   -d:               Run the container in the background (detached mode)
 #   --name cocoserver:  Assign a name to the container (cocoserver)
 #   -p 9000:9000:     Map the container's port 9000 to the host's port 9000 (Web UI port)
-#   infinilabs/coco:0.2.0-1992:  The Docker image name and tag (version) to use
-docker run -d --name cocoserver -p 9000:9000 infinilabs/coco:0.2.0-1992
+#   infinilabs/coco:0.2.1-1998:  The Docker image name and tag (version) to use
+docker run -d --name cocoserver -p 9000:9000 infinilabs/coco:0.2.1-1998
 
 # Stop and Remove Coco Server Container
 #
@@ -40,9 +40,9 @@ docker stop cocoserver && docker rm cocoserver
 # Remove Coco Server Docker Image
 #
 # Command Explanation:
-#   docker rmi infinilabs/coco:0.2.0-1992: Remove the image named infinilabs/coco with the tag 0.2.0-1992
+#   docker rmi infinilabs/coco:0.2.1-1998: Remove the image named infinilabs/coco with the tag 0.2.1-1998
 #   Note: You can only remove an image if no containers are using it.  If a container is using the image, you must first stop and remove the container.
-docker rmi infinilabs/coco:0.2.0-1992
+docker rmi infinilabs/coco:0.2.1-1998
 
 # --------------------------------------------------
 # Customized Configuration to Start Coco Server
@@ -71,7 +71,7 @@ sudo chown -R 602:602 $(pwd)/cocoserver
 #   -e ES_JAVA_OPTS="-Xms2g -Xmx2g":  Set the JVM parameters for Easysearch:
 #        - -Xms2g:  Set the initial JVM heap size to 2GB
 #        - -Xmx2g:  Set the maximum JVM heap size to 2GB
-#   infinilabs/coco:0.2.0-1992: The Docker image name and tag to use
+#   infinilabs/coco:0.2.1-1998: The Docker image name and tag to use
 
 docker run -d \
            --name cocoserver \
@@ -84,7 +84,7 @@ docker run -d \
            -v $(pwd)/cocoserver/logs:/app/easysearch/logs \
            -e EASYSEARCH_INITIAL_ADMIN_PASSWORD=coco-server \
            -e ES_JAVA_OPTS="-Xms2g -Xmx2g" \
-           infinilabs/coco:0.2.0-1992
+           infinilabs/coco:0.2.1-1998
 ```
 
 ### Download the Server


### PR DESCRIPTION
## What does this PR do
This pull request includes updates to the Docker image version used in the installation instructions for the Coco Server. The changes ensure that the documentation reflects the latest version of the Docker image.

Updates to Docker image version:

* [`docs/content.en/docs/getting-started/install.md`](diffhunk://#diff-9fa6f57fd4605d9676451a90930fe3c9fa0d0a47d6d3f972f2818d62b3fb6ac9L29-R30): Updated the Docker image version from `0.2.0-1992` to `0.2.1-1998` in multiple locations to ensure the documentation uses the latest image version. [[1]](diffhunk://#diff-9fa6f57fd4605d9676451a90930fe3c9fa0d0a47d6d3f972f2818d62b3fb6ac9L29-R30) [[2]](diffhunk://#diff-9fa6f57fd4605d9676451a90930fe3c9fa0d0a47d6d3f972f2818d62b3fb6ac9L43-R45) [[3]](diffhunk://#diff-9fa6f57fd4605d9676451a90930fe3c9fa0d0a47d6d3f972f2818d62b3fb6ac9L74-R74) [[4]](diffhunk://#diff-9fa6f57fd4605d9676451a90930fe3c9fa0d0a47d6d3f972f2818d62b3fb6ac9L87-R87)
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation