### PR TITLE
fix: provider info version

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,6 +12,7 @@ Information about release notes of Coco Server is provided here.
 ### Breaking changes
 ### Features
 ### Bug fix
+- Fixed provider info version (#144)
 ### Improvements
 
 ## 0.2.2 (2025-03-14)
@@ -25,7 +26,7 @@ Information about release notes of Coco Server is provided here.
 
 ### Bug fix
 
-- Fix: fatal error: concurrent map writes #125
+- Fixed fatal error: concurrent map writes #125
 
 ### Improvements
 - Enhance UI for Adding a New Data Source (#126)

--- a/modules/common/config.go
+++ b/modules/common/config.go
@@ -37,6 +37,7 @@ func AppConfig() Config {
 			err := util.FromJSONBytes(buf, si)
 			if err == nil {
 				config.ServerInfo = si
+				config.ServerInfo.Version = Version{global.Env().GetVersion()}
 			}
 		}
 		buf, _ = kv.GetValue(core.DefaultSettingBucketKey, []byte(core.DefaultLLMConfigKey))


### PR DESCRIPTION
## What does this PR do
This pull request includes a small change to the `modules/common/config.go` file. The change adds the server version information to the `config.ServerInfo` object.

* [`modules/common/config.go`](diffhunk://#diff-468ab3f0b032c10ba17cbb82c0cdda2a7252fbc57c98c0ecc93486ee55f062eeR40): Added the server version to the `config.ServerInfo` object in the `AppConfig` function.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation