### PR TITLE
feat: initialize default server endpoint based on request

### DIFF
--- a/modules/system/initialize.go
+++ b/modules/system/initialize.go
@@ -101,6 +101,13 @@ func (h *APIHandler) setupServer(w http.ResponseWriter, req *http.Request, ps ht
 	} else if info.ServerInfo.Name == "" {
 		info.ServerInfo.Name = "My Coco Server"
 	}
+	if info.ServerInfo.Endpoint == "" {
+		var schema = "http"
+		if req.TLS != nil {
+			schema = "https"
+		}
+		info.ServerInfo.Endpoint = fmt.Sprintf("%s://%s", schema, req.Host)
+	}
 
 	if input.Password == "" {
 		panic("password can't be empty")


### PR DESCRIPTION
## What does this PR do
This pull request includes an important change to the `modules/system/initialize.go` file to enhance the server setup process by automatically setting the server endpoint if it is not provided. 

Improvements to server setup:

* [`modules/system/initialize.go`](diffhunk://#diff-b78129ce01dbbb7ab2977a3ad2996658721102529f8da3a87ddee1e363274d1bR104-R110): Added logic to set the `ServerInfo.Endpoint` to a URL constructed from the request schema and host if it is not already specified. This ensures that the server endpoint is always correctly set, even if not explicitly provided.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation