### PR TITLE
feat: set built-in connector icons as readonly

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -15,6 +15,7 @@ Information about release notes of Coco Server is provided here.
 
 ### Bug fix  
 ### Improvements
+- Set built-in connector icons as read-only
 
 ## 0.3.0 (2025-03-31)
 


### PR DESCRIPTION
## What does this PR do
Set built-in connector icons as readonly
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation