### PR TITLE
improvement: check oauth config before creating new google drive datasource

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -23,6 +23,7 @@ Information about release notes of Coco Server is provided here.
 - Refactoring security plugin #199
 - searchbox's theme styles follows the system if searchbox's theme is set to `auto`
 - Support setting suggested topics of integration
+- When creating a new Google Drive datasource, guide the user to configure the required settings if they are missing.
 
 ## 0.3.0 (2025-03-31)
 

--- a/modules/connector/connector.go
+++ b/modules/connector/connector.go
@@ -67,6 +67,7 @@ func (h *APIHandler) update(w http.ResponseWriter, req *http.Request, ps httprou
 
 	var err error
 	var create *time.Time
+	var builtin bool
 	if !replace {
 		obj.ID = id
 		exists, err := orm.Get(&obj)
@@ -79,6 +80,7 @@ func (h *APIHandler) update(w http.ResponseWriter, req *http.Request, ps httprou
 		}
 		id = obj.ID
 		create = obj.Created
+		builtin = obj.Builtin
 	} else {
 		t := time.Now()
 		create = &t
@@ -94,6 +96,7 @@ func (h *APIHandler) update(w http.ResponseWriter, req *http.Request, ps httprou
 	//protect
 	obj.ID = id
 	obj.Created = create
+	obj.Builtin = builtin
 	ctx := &orm.Context{
 		Refresh: orm.WaitForRefresh,
 	}

--- a/web/src/locales/langs/en-us/page.ts
+++ b/web/src/locales/langs/en-us/page.ts
@@ -56,6 +56,7 @@ const page: App.I18n.Schema['translation']['page'] = {
       type: 'Type'
     },
     connect: 'Connect',
+    missing_config_tip: "Google authorization parameters are not configured. Please set them before connecting. Click Confirm to go to the settings page.",
     delete: {
       confirm: 'Are you sure you want to delete this datasource?'
     },

--- a/web/src/locales/langs/zh-cn/page.ts
+++ b/web/src/locales/langs/zh-cn/page.ts
@@ -56,6 +56,7 @@ const page: App.I18n.Schema['translation']['page'] = {
       type: '类型'
     },
     connect: '连接',
+    missing_config_tip: "Google 授权相关参数没有设置，需设置后才能连接，点击确认跳转到设置页面。",
     delete: {
       confirm: '确定删除这个数据源？'
     },

--- a/web/src/pages/data-source/new/google_drive.tsx
+++ b/web/src/pages/data-source/new/google_drive.tsx
@@ -1,13 +1,58 @@
-import { Button } from 'antd';
+import { Button, Modal } from "antd";
+import { ExclamationCircleOutlined } from "@ant-design/icons";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
-export default () => {
+const { confirm } = Modal;
+
+interface GoogleDriveProps {
+  connector: {
+    config?: {
+      client_id?: string;
+      client_secret?: string;
+      auth_url?: string;
+      redirect_url?: string;
+      token_url?: string;
+    };
+  };
+}
+
+export default ({ connector }: GoogleDriveProps) => {
   const { t } = useTranslation();
+  const nav = useNavigate();
+  connector.config = {};
+
+  const onConnectClick = () => {
+    const config = connector?.config || {};
+
+    const missingFields = [
+      config.client_id,
+      config.client_secret,
+      config.auth_url,
+      config.redirect_url,
+      config.token_url,
+    ].some((field) => !field);
+
+    if (missingFields) {
+      confirm({
+        title: t("common.tip"),
+        icon: <ExclamationCircleOutlined />,
+        content: t('page.datasource.missing_config_tip'),
+        okText: t("common.confirm"),
+        cancelText: t("common.cancel"),
+        onOk() {
+          nav("/connector/edit/google_drive", {state: connector });
+        },
+      });
+    } else {
+      window.location.href = `${window.location.origin}/connector/google_drive/connect`;
+    }
+  };
+
   return (
     <div className="flex items-center justify-between px-20px">
-      <Button type="primary">
-        <a href={`${window.location.origin}/connector/google_drive/connect`}>
-          {t('page.datasource.new.labels.connect')}
-        </a>
+      <Button type="primary" onClick={onConnectClick}>
+        {t("page.datasource.new.labels.connect")}
       </Button>
     </div>
   );

--- a/web/src/pages/data-source/new/google_drive.tsx
+++ b/web/src/pages/data-source/new/google_drive.tsx
@@ -20,7 +20,6 @@ interface GoogleDriveProps {
 export default ({ connector }: GoogleDriveProps) => {
   const { t } = useTranslation();
   const nav = useNavigate();
-  connector.config = {};
 
   const onConnectClick = () => {
     const config = connector?.config || {};

--- a/web/src/pages/data-source/new/index.tsx
+++ b/web/src/pages/data-source/new/index.tsx
@@ -169,7 +169,7 @@ export function Component() {
           </div>
         </div>
         {type === Types.GoogleDrive ? (
-          <GoogleDrive />
+          <GoogleDrive connector={connector} />
         ) : (
           <div>
             <Form


### PR DESCRIPTION
## What does this PR do
When creating a new Google Drive datasource, guide the user to configure the required settings if they are missing.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation