### PR TITLE
fix: handle empty MCP config when type is stdio

### DIFF
--- a/web/src/pages/mcp-server/modules/EditForm.tsx
+++ b/web/src/pages/mcp-server/modules/EditForm.tsx
@@ -56,6 +56,8 @@ export const EditForm = memo((props: MCPServerFormProps)=> {
     if(values.type === "stdio"){
       if(values.config?.args){
         values.config.args = values.config.args?.split("\n");
+      }else{
+        values.config.args = [];
       }
       if(values.config?.env){
         const env: any = {}
@@ -64,6 +66,8 @@ export const EditForm = memo((props: MCPServerFormProps)=> {
           env[key] = value;
         })
         values.config.env = env;
+      }else{
+        values.config.env = {};
       }
     }
     onSubmit?.(values, startLoading, endLoading);


### PR DESCRIPTION
## What does this PR do
handle empty MCP config when type is stdio
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation