### PR TITLE
fix: incorrect content-type header for wrapper

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -18,6 +18,8 @@ Information about release notes of Coco Server is provided here.
 
 ### Bug fix  
 - Fix personal token was not well supported for Yuque connector
+- Fix incorrect content-type header for wrapper
+
 
 ### Improvements
 - Set built-in connector icons as read-only

--- a/modules/integration/wrapper.go
+++ b/modules/integration/wrapper.go
@@ -77,8 +77,7 @@ func (h *APIHandler) widgetWrapper(w http.ResponseWriter, req *http.Request, ps 
 		}
 		return -1, nil
 	})
-
-	h.Write(w, []byte(str))
 	h.WriteJavascriptHeader(w)
+	h.Write(w, []byte(str))
 	h.WriteHeader(w, 200)
 }


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation