### PR TITLE
fix: add missing cors feature flags to settings api

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -11,8 +11,10 @@ Information about release notes of Coco Server is provided here.
 ### ❌ Breaking changes  
 ### 🚀 Features  
 ### 🐛 Bug fix  
+- fix: add missing cors feature flags to settings api
+
 ### ✈️ Improvements  
-- Clean up unused LLM settings code
+- chore: clean up unused LLM settings code
 
 ## 0.4.0 (2025-04-27)
 ### Breaking changes  

--- a/modules/system/init.go
+++ b/modules/system/init.go
@@ -24,6 +24,7 @@
 package system
 
 import (
+	"infini.sh/coco/core"
 	"infini.sh/coco/modules/common"
 	"infini.sh/coco/plugins/security/filter"
 	"infini.sh/framework/core/api"
@@ -48,12 +49,15 @@ func init() {
 
 	security.GetOrInitPermissionKey(readPermission)
 	security.GetOrInitPermissionKey(updatePermission)
+	security.RegisterPermissionsToRole(core.WidgetRole, readPermission)
 
 	handler := APIHandler{}
 	api.HandleUIMethod(api.GET, "/provider/_info", handler.providerInfo, api.AllowPublicAccess())
 	api.HandleUIMethod(api.POST, "/setup/_initialize", handler.setupServer, api.AllowPublicAccess())
 
-	api.HandleUIMethod(api.GET, "/settings", handler.getServerSettings, api.RequirePermission(readPermission), api.Feature(filter.FeatureCORS))
+	api.HandleUIMethod(api.OPTIONS, "/settings", handler.getServerSettings, api.RequirePermission(readPermission), api.Feature(filter.FeatureCORS))
+	api.HandleUIMethod(api.GET, "/settings", handler.getServerSettings, api.RequirePermission(readPermission), api.Feature(filter.FeatureCORS), api.Feature(filter.FeatureMaskSensitiveField),
+		api.Feature(filter.RemoveSensitiveField))
 	api.HandleUIMethod(api.PUT, "/settings", handler.updateServerSettings, api.RequirePermission(updatePermission))
 
 	//list all icons for connectors


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation