### PR TITLE
fix: handle empty URL values in HugoSite-type datasource

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -14,6 +14,7 @@ Information about release notes of Coco Server is provided here.
 
 ### 🐛 Bug fix  
 - fix: add missing cors feature flags to settings api
+- fix: handle empty URL values in HugoSite-type datasource
 
 ### ✈️ Improvements  
 - chore: clean up unused LLM settings code

--- a/web/src/components/datasource/type/urls.jsx
+++ b/web/src/components/datasource/type/urls.jsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 
 export const MultiURLInput = ({ onChange, showLabel = true, value = [''] }) => {
   const [urls, setUrls] = useState(value);
+  debugger
   const { t } = useTranslation();
 
   const handleChange = (index, value) => {

--- a/web/src/components/datasource/type/urls.jsx
+++ b/web/src/components/datasource/type/urls.jsx
@@ -4,7 +4,6 @@ import React, { useState } from 'react';
 
 export const MultiURLInput = ({ onChange, showLabel = true, value = [''] }) => {
   const [urls, setUrls] = useState(value);
-  debugger
   const { t } = useTranslation();
 
   const handleChange = (index, value) => {

--- a/web/src/pages/data-source/edit/[id].tsx
+++ b/web/src/pages/data-source/edit/[id].tsx
@@ -129,7 +129,7 @@ export function Component() {
       datasource.token = datasource?.connector?.config?.token || '';
       break;
     case Types.HugoSite:
-      datasource.urls = datasource?.connector?.config?.urls || [];
+      datasource.urls = datasource?.connector?.config?.urls || [''];
       break;
     case Types.GoogleDrive:
       break;

--- a/web/src/pages/data-source/list/index.tsx
+++ b/web/src/pages/data-source/list/index.tsx
@@ -87,9 +87,8 @@ export function Component() {
     }
   };
   const onSyncEnabledChange = (value: boolean, record: Datasource) => {
-    record.sync_enabled = value;
     setLoading(true);
-    updateDatasource(record.id, record)
+    updateDatasource(record.id, {sync_enabled: value})
       .then(res => {
         if (res.data?.result === 'updated') {
           message.success(t('common.updateSuccess'));


### PR DESCRIPTION
## What does this PR do
fix: handle empty URL values in HugoSite-type datasource
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation