### PR TITLE
feat: return number of assistants in provider info API

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,6 +12,7 @@ Information about release notes of Coco Server is provided here.
 ### ❌ Breaking changes
 
 ### 🚀 Features
+- feat: return number of assistants in provider info API
 
 ### 🐛 Bug fix
 

--- a/modules/common/assistant.go
+++ b/modules/common/assistant.go
@@ -224,3 +224,14 @@ func GetAssistant(assistantID string) (*Assistant, bool, error) {
 	GeneralObjectCache.Set(AssistantCachePrimary, assistantID, assistant, time.Duration(30)*time.Minute)
 	return assistant, true, nil
 }
+
+func CountAssistants() (int64, error) {
+	queryDsl := util.MapStr{
+		"query": util.MapStr{
+			"term": util.MapStr{
+				"enabled": true,
+			},
+		},
+	}
+	return orm.Count(Assistant{}, util.MustToJSONBytes(queryDsl))
+}

--- a/modules/system/init.go
+++ b/modules/system/init.go
@@ -24,6 +24,8 @@
 package system
 
 import (
+	"net/http"
+
 	"infini.sh/coco/core"
 	"infini.sh/coco/modules/common"
 	"infini.sh/coco/plugins/security/filter"
@@ -32,7 +34,6 @@ import (
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/security"
 	"infini.sh/framework/core/util"
-	"net/http"
 )
 
 type APIHandler struct {
@@ -96,6 +97,16 @@ func (h *APIHandler) providerInfo(w http.ResponseWriter, req *http.Request, ps h
 			panic("sso url can't be nil")
 		}
 	}
+	stats := util.MapStr{}
+	claims, _ := core.ValidateLogin(req)
+	if claims != nil {
+		count, err := common.CountAssistants()
+		if err != nil {
+			panic(err)
+		}
+		stats["assistant_count"] = count
+	}
+	output["stats"] = stats
 
 	h.WriteJSON(w, output, 200)
 }


### PR DESCRIPTION
## What does this PR do
Return number of assistants in provider info API
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation