### PR TITLE
docs: update to latest tag

### DIFF
--- a/docs/content.en/docs/getting-started/install.md
+++ b/docs/content.en/docs/getting-started/install.md
@@ -20,8 +20,8 @@ asciinema: true
 #   -d:               Run the container in the background (detached mode)
 #   --name cocoserver:  Assign a name to the container (cocoserver)
 #   -p 9000:9000:     Map the container's port 9000 to the host's port 9000 (Web UI port)
-#   infinilabs/coco:0.4.0-2008:  The Docker image name and tag (version) to use
-docker run -d --name cocoserver -p 9000:9000 infinilabs/coco:0.4.0-2008
+#   infinilabs/coco:0.5.0-2236:  The Docker image name and tag (version) to use
+docker run -d --name cocoserver -p 9000:9000 infinilabs/coco:0.5.0-2236
 
 # Stop and Remove Coco Server Container
 #
@@ -34,9 +34,9 @@ docker stop cocoserver && docker rm cocoserver
 # Remove Coco Server Docker Image
 #
 # Command Explanation:
-#   docker rmi infinilabs/coco:0.4.0-2008: Remove the image named infinilabs/coco with the tag 0.4.0-2008
+#   docker rmi infinilabs/coco:0.5.0-2236: Remove the image named infinilabs/coco with the tag 0.5.0-2236
 #   Note: You can only remove an image if no containers are using it.  If a container is using the image, you must first stop and remove the container.
-docker rmi infinilabs/coco:0.4.0-2008
+docker rmi infinilabs/coco:0.5.0-2236
 
 # --------------------------------------------------
 # Customized Configuration to Start Coco Server
@@ -65,7 +65,7 @@ sudo chown -R 602:602 $(pwd)/cocoserver
 #   -e ES_JAVA_OPTS="-Xms2g -Xmx2g":  Set the JVM parameters for Easysearch:
 #        - -Xms2g:  Set the initial JVM heap size to 2GB
 #        - -Xmx2g:  Set the maximum JVM heap size to 2GB
-#   infinilabs/coco:0.4.0-2008: The Docker image name and tag to use
+#   infinilabs/coco:0.5.0-2236: The Docker image name and tag to use
 
 docker run -d \
            --name cocoserver \
@@ -78,7 +78,7 @@ docker run -d \
            -v $(pwd)/cocoserver/logs:/app/easysearch/logs \
            -e EASYSEARCH_INITIAL_ADMIN_PASSWORD=coco-server \
            -e ES_JAVA_OPTS="-Xms2g -Xmx2g" \
-           infinilabs/coco:0.4.0-2008
+           infinilabs/coco:0.5.0-2236
 ```
 
 


### PR DESCRIPTION
The old Tag does not exist in Docker. Update to use the latest one.

## What does this PR do
Update to use the latest one.

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation