### PR TITLE
chore: ignore empty chunk_message

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -46,7 +46,7 @@ Information about release notes of Coco Server is provided here.
 - chore: password supports more special characters
 - refactor: refactoring chat api #273
 - chore: add placeholder, category and tags to AI Assistant
-
+- chore: ignore empty chunk_message #288
 
 ## 0.4.0 (2025-04-27)
 

--- a/modules/assistant/streaming-http.go
+++ b/modules/assistant/streaming-http.go
@@ -24,6 +24,11 @@ type HTTPStreamSender struct {
 }
 
 func (s *HTTPStreamSender) SendMessage(msg *common.MessageChunk) error {
+
+	if msg == nil || (msg.MessageType == common.Response && msg.MessageChunk == "") {
+		return nil
+	}
+
 	select {
 	case <-s.Ctx.Done():
 		return fmt.Errorf("client disconnected")


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation