### PR TITLE
fix: remove manually_renamed_title from assistant search

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -11,6 +11,8 @@ Information about release notes of Coco Server is provided here.
 ### ❌ Breaking changes  
 ### 🚀 Features  
 ### 🐛 Bug fix  
+- fix: remove manually_renamed_title from assistant search
+
 ### ✈️ Improvements  
 
 ## 0.5.0 (2025-06-06)

--- a/modules/assistant/session.go
+++ b/modules/assistant/session.go
@@ -138,7 +138,7 @@ func (h APIHandler) updateSession(w http.ResponseWriter, req *http.Request, ps h
 
 func (h APIHandler) getChatSessions(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 
-	builder, err := orm.NewQueryBuilderFromRequest(req, "title", "summary", "manually_renamed_title")
+	builder, err := orm.NewQueryBuilderFromRequest(req, "title", "summary")
 	if err != nil {
 		h.WriteError(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation