### PR TITLE
chore: make AI assistant, mcp server and LLM provider names clickable

### DIFF
--- a/web/src/pages/ai-assistant/list/index.tsx
+++ b/web/src/pages/ai-assistant/list/index.tsx
@@ -104,7 +104,7 @@ export function Component() {
             <IconWrapper className="w-20px h-20px">
               <InfiniIcon height="1em" width="1em" src={record.icon} />
             </IconWrapper>
-            <span className='max-w-150px ant-table-cell-ellipsis'>{ value }</span>
+            <span className='max-w-150px ant-table-cell-ellipsis cursor-pointer hover:text-blue-500' onClick={()=>nav(`/ai-assistant/edit/${record.id}`)}>{ value }</span>
             {record.builtin === true && <div className="flex items-center ml-[5px]">
               <p className="h-[22px] bg-[#eee] text-[#999] font-size-[12px] px-[10px] line-height-[22px] rounded-[4px]">{t('page.modelprovider.labels.builtin')}</p>
             </div>}

--- a/web/src/pages/mcp-server/list/index.tsx
+++ b/web/src/pages/mcp-server/list/index.tsx
@@ -92,7 +92,7 @@ export function Component() {
             <IconWrapper className="w-20px h-20px">
               <InfiniIcon height="1em" width="1em" src={record.icon} />
             </IconWrapper>
-            <span className='max-w-150px ant-table-cell-ellipsis'>{ value }</span>
+            <span className='max-w-150px ant-table-cell-ellipsis cursor-pointer hover:text-blue-500' onClick={()=>nav(`/mcp-server/edit/${record.id}`, {state:record})}>{ value }</span>
           </div>
         )
       }

--- a/web/src/pages/model-provider/list/index.tsx
+++ b/web/src/pages/model-provider/list/index.tsx
@@ -146,7 +146,7 @@ export function Component() {
                         <IconWrapper className="w-40px h-40px">
                           <InfiniIcon src={provider.icon} height="2em" width="2em" className="font-size-2em"/>
                         </IconWrapper>
-                        <span className="font-size-1.2em">{provider.name}</span>
+                        <span className="font-size-1.2em cursor-pointer hover:text-blue-500" onClick={()=>nav(`/model-provider/edit/${provider.id}`)}>{provider.name}</span>
                       </div>
                       {provider.builtin === true && <div className="flex items-center">
                         <p className="h-[22px] bg-[#eee] text-[#999] font-size-[12px] px-[10px] line-height-[22px] rounded-[4px]">{t('page.modelprovider.labels.builtin')}</p>


### PR DESCRIPTION
## What does this PR do

chore: make ai assistant, mcp server and llm provider names clickable and enter the edit mode by default

## Rationale for this change

usability enhancement

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation