### PR TITLE
improve: hide delete button for built-in assistants and providers

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -37,6 +37,7 @@ Information about release notes of Coco Server is provided here.
 - chore: add fullscreen to integration #373
 - chore: ignore invalid connector #379
 - chore: skip invalid mcp server #380
+- improve: hide delete button for built-in assistants and providers
 
 ## 0.6.0 (2025-06-29)
 ### ❌ Breaking changes  

--- a/web/src/pages/ai-assistant/list/index.tsx
+++ b/web/src/pages/ai-assistant/list/index.tsx
@@ -17,20 +17,26 @@ export function Component() {
   const { scrollConfig, tableWrapperRef } = useTableScroll();
 
   const nav = useNavigate();
-  const items: MenuProps["items"] = [
-    {
-      label: t('common.edit'),
-      key: "2",
-    },
-    {
-      label: t('common.delete'),
-      key: "1",
-    },
-    {
+
+  const getMenuItems = useCallback((record: Assistant): MenuProps["items"] => {
+    const items: MenuProps["items"] = [
+      {
+        label: t('common.edit'),
+        key: "2",
+      },
+    ];
+    if (record.builtin !== true) {
+      items.push({
+        label: t('common.delete'),
+        key: "1",
+      });
+    }
+    items.push({
       label: t('common.clone'),
       key: "3",
-    },
-  ];
+    })
+    return items;
+  }, []);
 
   const onMenuClick = ({key, record}: any)=>{
     switch(key){
@@ -155,7 +161,7 @@ export function Component() {
       fixed: 'right',
       width: "90px",
       render: (_, record) => {
-        return <Dropdown menu={{ items, onClick:({key})=>onMenuClick({key, record}) }}>
+        return <Dropdown menu={{ items: getMenuItems(record), onClick:({key})=>onMenuClick({key, record}) }}>
           <EllipsisOutlined/>
         </Dropdown>
       },

--- a/web/src/pages/model-provider/list/index.tsx
+++ b/web/src/pages/model-provider/list/index.tsx
@@ -42,16 +42,22 @@ export function Component() {
       }
     })
   }
-  const items: MenuProps["items"] = [
-    {
-      label: t('common.edit'),
-      key: "1",
-    },
-    {
-      label: t('common.delete'),
-      key: "2",
-    },
-  ];
+  const getMenuItems = useCallback((record: any): MenuProps["items"] => {
+    const items: MenuProps["items"] = [
+      {
+        label: t('common.edit'),
+        key: "1",
+      },
+    ];
+    if(record.builtin !== true) {
+      items.push({
+        label: t('common.delete'),
+        key: "2",
+      });
+    }
+    return items;
+  }, []);
+  
   const onMenuClick = ({key, record}: any)=>{
     switch(key){
       case "2":
@@ -164,7 +170,7 @@ export function Component() {
                     <div className="ml-auto flex gap-2">
                       <div onClick={()=>{onAPIKeyClick(provider)}} className="border border-[var(--ant-color-border)] cursor-pointer  px-10px rounded-[8px]">API-key</div>
                       <div className="inline-block px-4px rounded-[8px] border border-[var(--ant-color-border)] cursor-pointer">
-                        <Dropdown menu={{ items, onClick:({key})=>onMenuClick({key, record: provider}) }}>
+                        <Dropdown menu={{ items: getMenuItems(provider), onClick:({key})=>onMenuClick({key, record: provider}) }}>
                             <SettingOutlined className="text-blue-500"/>
                         </Dropdown>
                       </div>


### PR DESCRIPTION
## What does this PR do
hide delete button for built-in assistants and providers
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation