### PR TITLE
docs: enable syntax highlight for shell scripts

### DIFF
--- a/docs/content.en/docs/getting-started/install.md
+++ b/docs/content.en/docs/getting-started/install.md
@@ -160,12 +160,14 @@ Follow these steps for a manual setup:
 ### Easysearch
 
 Install Easysearch
-```
+
+```bash
 docker run -itd --name easysearch -p 9200:9200 infinilabs/easysearch:1.8.3-265
 ```
 
 Get the bootstrap password of the Easysearch:
-```
+
+```bash
 docker logs easysearch | grep "admin:"
 ```
 
@@ -173,8 +175,8 @@ docker logs easysearch | grep "admin:"
 
 Modify `coco.yml` with correct `env` settings, or start the coco server with the correct environments like this:
 
-```
-➜  coco git:(main) ✗ OLLAMA_MODEL=deepseek-r1:1.5b ES_PASSWORD=45ff432a5428ade77c7b  ./bin/coco
+```bash
+$ OLLAMA_MODEL=deepseek-r1:1.5b ES_PASSWORD=45ff432a5428ade77c7b  ./bin/coco
    ___  ___  ___  ___     _     _____
   / __\/___\/ __\/___\   /_\    \_   \
  / /  //  // /  //  //  //_\\    / /\/


### PR DESCRIPTION
## What does this PR do

This commit adds shell script syntax highlight for the following section in `docs/content.en/docs/getting-started/install.md`:

<img width="1085" height="1077" alt="Screenshot 2025-07-20 at 2 44 36 PM" src="https://github.com/user-attachments/assets/948e29d2-f6a5-4318-b33d-93b33a340ecc" />


## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation