### PR TITLE
fix: English guide/setup page POST request data format error, http 400

### DIFF
--- a/config/setup/en-US/assistant.tpl
+++ b/config/setup/en-US/assistant.tpl
@@ -70,7 +70,7 @@ POST $[[SETUP_INDEX_PREFIX]]assistant$[[SETUP_SCHEMA_VER]]/$[[SETUP_DOC_TYPE]]/a
       "provider_id": "$[[SETUP_LLM_PROVIDER_ID]]",
       "name": "$[[SETUP_LLM_DEFAULT_MODEL_ID]]",
       "settings": {
-        "reasoning": "reasoning": $[[SETUP_LLM_REASONING]],
+        "reasoning": $[[SETUP_LLM_REASONING]],
         "temperature": 0,
         "top_p": 0,
         "presence_penalty": 0,


### PR DESCRIPTION
## What does this PR do

Bug Fix

## Rationale for this change

English guide page data form is broken

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation