### PR TITLE
fix: assign created time when creating a new reply message

### DIFF
--- a/modules/assistant/background_job.go
+++ b/modules/assistant/background_job.go
@@ -29,6 +29,7 @@ import (
 	"net/http"
 	"runtime"
 	"strings"
+	"time"
 
 	"infini.sh/coco/modules/assistant/rag"
 	"infini.sh/coco/modules/datasource"
@@ -216,6 +217,8 @@ func (h APIHandler) createAssistantMessage(sessionID, assistantID, requestMessag
 		ReplyMessageID: requestMessageID,
 		AssistantID:    assistantID,
 	}
+	now := time.Now()
+	msg.Created = &now
 	msg.ID = util.GetUUID()
 
 	return msg
@@ -856,7 +859,7 @@ func (h APIHandler) generateFinalResponse(taskCtx context.Context, reqMsg, reply
 
 	echoMsg := common.NewMessageChunk(params.SessionID, replyMsg.ID, common.MessageTypeAssistant, reqMsg.ID, common.Response, string(""), 0)
 	_ = sender.SendMessage(echoMsg)
-	reqMsg.Message += echoMsg.MessageChunk
+	replyMsg.Message += echoMsg.MessageChunk
 
 	// Prepare the system message
 	content := []llms.MessageContent{

--- a/modules/assistant/session.go
+++ b/modules/assistant/session.go
@@ -474,7 +474,7 @@ func (h APIHandler) getChatHistoryBySession(w http.ResponseWriter, req *http.Req
 	q.Conds = orm.And(orm.Eq("session_id", ps.MustGetParameter("session_id")))
 	q.From = h.GetIntOrDefault(req, "from", 0)
 	q.Size = h.GetIntOrDefault(req, "size", 20)
-	q.AddSort("updated", orm.ASC)
+	q.AddSort("created", orm.ASC)
 
 	err, res := orm.Search(&common.ChatMessage{}, &q)
 	if err != nil {


### PR DESCRIPTION
## What does this PR do
assign created time when creating a new reply message to ensure correct message history sorting

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation