### PR TITLE
fix: add missing defer file.Close() to prevent file handle leak

### DIFF
--- a/modules/assistant/utils.go
+++ b/modules/assistant/utils.go
@@ -18,6 +18,7 @@ func TextToChunks(dirFile string, chunkSize, chunkOverlap int) ([]schema.Documen
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 	// Create a new text document loader
 	docLoaded := documentloaders.NewText(file)
 	// Create a new recursive character text splitter


### PR DESCRIPTION
## Summary
Fix critical resource leak in `TextToChunks` function by adding missing `defer file.Close()` statement.

## Problem
The `TextToChunks` function in `modules/assistant/utils.go` was opening a file with `os.Open()` but not properly closing it, causing file handle leaks that could lead to resource exhaustion.

## Solution
- Added `defer file.Close()` immediately after the error check on line 21
- Ensures file handle is released when function returns (normal or error case)
- Follows Go best practices for resource management

## Testing
- [x] Code compiles without errors
- [x] Follows Go resource management patterns
- [x] Handles error cases properly

## Impact
- **Critical**: Prevents file descriptor exhaustion in production
- **Performance**: Reduces resource consumption
- **Reliability**: Eliminates potential service degradation over time

## Files Changed
- `modules/assistant/utils.go`

🤖 Generated with [Claude Code](https://claude.ai/code)