### PR TITLE
fix: correct assistant update logic

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -11,6 +11,7 @@ Information about release notes of Coco Server is provided here.
 ### ❌ Breaking changes  
 ### 🚀 Features  
 ### 🐛 Bug fix  
+- fix: correct assistant update logic
 ### ✈️ Improvements  
 - chore: remove unused websocket api #443
 

--- a/modules/assistant/assistant.go
+++ b/modules/assistant/assistant.go
@@ -24,9 +24,10 @@
 package assistant
 
 import (
-	"infini.sh/coco/core"
 	"net/http"
 	"time"
+
+	"infini.sh/coco/core"
 
 	log "github.com/cihub/seelog"
 	"infini.sh/coco/modules/common"
@@ -91,7 +92,7 @@ func (h *APIHandler) updateAssistant(w http.ResponseWriter, req *http.Request, p
 	}
 
 	newObj := common.Assistant{}
-	err = h.DecodeJSON(req, &obj)
+	err = h.DecodeJSON(req, &newObj)
 	if err != nil {
 		h.WriteError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -107,7 +108,7 @@ func (h *APIHandler) updateAssistant(w http.ResponseWriter, req *http.Request, p
 
 	ctx.Refresh = orm.WaitForRefresh
 
-	err = orm.Save(ctx, &obj)
+	err = orm.Save(ctx, &newObj)
 	if err != nil {
 		h.WriteError(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## What does this PR do
This pull request includes changes to fix an issue with the assistant update logic, improve code readability, and update the release notes documentation. The most important changes are grouped and summarized below.

### Bug Fixes:
* Corrected the assistant update logic by replacing references to the `obj` variable with `newObj` in `func (h *APIHandler) updateAssistant` to ensure the correct data is processed and saved (`modules/assistant/assistant.go`). [[1]](diffhunk://#diff-f3a3406514a568c159d1d4c12dc0649f540747eb6418d981d843b0e2a32bb227L94-R95) [[2]](diffhunk://#diff-f3a3406514a568c159d1d4c12dc0649f540747eb6418d981d843b0e2a32bb227L110-R111)

### Documentation:
* Updated the release notes to include a new bug fix entry: "fix: correct assistant update logic" (`docs/content.en/docs/release-notes/_index.md`).

### Code Quality Improvements:
* Reorganized imports in `modules/assistant/assistant.go` to improve readability by grouping related packages together.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation