### PR TITLE
fix: generate unique icon key to prevent accidental deletion of all icons

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,6 +12,7 @@ Information about release notes of Coco Server is provided here.
 ### 🚀 Features  
 ### 🐛 Bug fix  
 - fix: correct assistant update logic
+- fix: generate unique icon key to prevent accidental deletion of all icons
 ### ✈️ Improvements  
 - chore: remove unused websocket api #443
 

--- a/modules/connector/connector.go
+++ b/modules/connector/connector.go
@@ -5,13 +5,14 @@
 package connector
 
 import (
+	"net/http"
+	"time"
+
 	"infini.sh/coco/core"
 	"infini.sh/coco/modules/common"
 	httprouter "infini.sh/framework/core/api/router"
 	"infini.sh/framework/core/orm"
 	"infini.sh/framework/core/util"
-	"net/http"
-	"time"
 )
 
 func (h *APIHandler) create(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
@@ -104,7 +105,7 @@ func (h *APIHandler) update(w http.ResponseWriter, req *http.Request, ps httprou
 
 	ctx.Refresh = orm.WaitForRefresh
 
-	err = orm.Update(ctx, &obj)
+	err = orm.Save(ctx, &obj)
 	if err != nil {
 		h.WriteError(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/web/src/pages/connector/new/assets_icons.jsx
+++ b/web/src/pages/connector/new/assets_icons.jsx
@@ -4,20 +4,21 @@ import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { IconSelector } from './icon_selector';
+import { getUUID } from "@/utils/common";
 
 export const AssetsIcons = ({ iconsMeta = [], onChange, value = {} }) => {
   const { t } = useTranslation();
   const initialIcons = Object.keys(value).map(k => {
     return {
       icon: value[k],
-      key: new Date().getTime(),
+      key: getUUID(),
       type: k
     };
   });
   if (!initialIcons.length) {
     initialIcons.push({
       icon: '',
-      key: new Date().getTime(),
+      key: getUUID(),
       type: ''
     });
   }
@@ -57,7 +58,7 @@ export const AssetsIcons = ({ iconsMeta = [], onChange, value = {} }) => {
         ...oldIcons,
         {
           icon: undefined,
-          key: new Date().getTime(),
+          key:  getUUID(),
           type: ''
         }
       ];


### PR DESCRIPTION
## What does this PR do
This pull request introduces a bug fix and a code improvement to enhance the reliability of icon management in the application. The most notable changes include replacing the logic for generating unique keys for icons with a more robust UUID-based approach and updating the release notes to reflect the fix.

### Bug Fixes:
* Updated the release notes to include a new fix: "generate unique icon key to prevent accidental deletion of all icons." (`docs/content.en/docs/release-notes/_index.md`)

### Code Improvements:
* Replaced `new Date().getTime()` with `getUUID()` for generating unique keys in `AssetsIcons` to ensure uniqueness and prevent potential key collisions. (`web/src/pages/connector/new/assets_icons.jsx`) [[1]](diffhunk://#diff-f01486a4b69ef6f0a618da4ad09316c46e5384332fa38801d5fd755c79d8fc3aR7-R21) [[2]](diffhunk://#diff-f01486a4b69ef6f0a618da4ad09316c46e5384332fa38801d5fd755c79d8fc3aL60-R61)
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation