### PR TITLE
fix: modify the access_token URL during coco server login (#480)

### DIFF
--- a/web/src/service/api/auth.ts
+++ b/web/src/service/api/auth.ts
@@ -62,7 +62,7 @@ export function fetchRefreshToken(refreshToken: string) {
 
 export function fetchAccessToken() {
   return request<Api.Auth.LoginToken>({
-    url: '/auth/request_access_token',
+    url: '/auth/access_token',
     method: 'post'
   });
 }


### PR DESCRIPTION
## What does this PR do
Update COCO server login and fetchAccessToken URLs

## Rationale for this change
Modified the login redirect URL of the COCO server to ensure proper redirection after login.

Updated the fetchAccessToken request URL to /auth/access_token for correct access token retrieval.

These changes fix the login redirection failure and 404 Not Found errors when connecting to the local COCO server

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation