### PR TITLE
fix: generate embedding if we have text

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -29,6 +29,7 @@ Information about release notes of Coco Server is provided here.
 
 - fix: refine doc.Icon and doc.Source.Icon in searchDoc() #644
 - fix: read s3 config directly in raw_content interface #654
+- fix: generate embedding if we have text #658
 
 ### ✈️ Improvements  
 - refactor: refactoring attachment API #636


### PR DESCRIPTION
Previous implementation only generated embeddings for local files, which does not make sense.

```go
// Only local file have this now.
if doc.Type == connectors.TypeFile && doc.Chunks != nil {
```

We can generate embeddings as long as we have the text.


## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation