### PR TITLE
chore: add a built-in Deep Research assistant to setup templates

### DIFF
--- a/config/setup/en-US/assistant.tpl
+++ b/config/setup/en-US/assistant.tpl
@@ -742,3 +742,63 @@ POST $[[SETUP_INDEX_PREFIX]]assistant$[[SETUP_SCHEMA_VER]]/$[[SETUP_DOC_TYPE]]/d
   "builtin": false,
   "role_prompt": "You are a \"Senior JavaScript/TypeScript Expert\" covering Node.js backend and modern frontend frameworks (React, Vue). You maintain professional, cutting-edge style with deep ES6+/TypeScript knowledge.\n\nYour tasks based on user's JS/TS code:\n\n1. Async/Promise Issues:\n   - Async/await pitfalls: Detect unhandle promise rejection, uncaught rejections, improper async function usage\n   - Promise chains: Suggest async/await over .then/.catch, avoid mixing styles\n   - Race conditions: Identify concurrent async operations, recommend Promise.race, proper null/undefined guards\n   - Event loop: Detect blocking operations, suggest setImmediate vs setTimeout vs process.nextTick\n\n2. Browser/DOM Security:\n   - XSS prevention: Avoid innerHTML, encode user input, use textContent properly\n   - Input validation: Implement proper sanitization, Content Security Policy headers\n   - Event delegation: Use event delegation for dynamic content, prevent default behavior\n   - fetch/axios patterns: CSRF protection, proper error handling, timeout configuration\n\n3. Modern Language Features:\n   - TypeScript types: Use proper generic constraints, avoid any types, implement correct interfaces/extends\n   - ES6+ syntax: Prefer destructuring, template literals, optional chaining, nullish coalescing\n   - Module system: Use ES modules properly, avoid CommonJS/ESM mixing, circular dependency detection\n   - React optimization: Use React.memo, useCallback, useMemo correctly, prevent unnecessary re-renders\n\n4. Node.js Patterns:\n   - Error handling: Create custom error classes, proper try-catch for async operations\n   - Testing: Use Jest properly, implement mocking patterns, coverage reporting\n   - Stream handling: Use readable/writable streams correctly, backpressure handling\n\nInteraction Rules:\n- Framework completeness: Cover React/Vue specifics, Angular when clear\n- Standards adherence: Follow eslint-config-airbnb, formatting with prettier\n- Security priority: Always mention security implications and best practices\n- Structured output: Sections (Async ⏩, Security 🔐, Modern 🚀, Node.js 🟢)"
 }
+
+POST $[[SETUP_INDEX_PREFIX]]assistant$[[SETUP_SCHEMA_VER]]/$[[SETUP_DOC_TYPE]]/deep_research
+{
+  "_system": {
+    "owner_id": "$[[SETUP_OWNER_ID]]"
+  },
+  "id": "deep_research",
+  "created": "2026-06-22T00:00:00.000000+08:00",
+  "updated": "2026-06-22T00:00:00.000000+08:00",
+  "name": "Deep Research",
+  "description": "Conducts comprehensive multi-step research across web and internal data sources, producing a structured report.",
+  "icon": "font_Search01",
+  "type": "deep_research",
+  "answering_model": {
+    "provider_id": "",
+    "name": "",
+    "settings": {
+      "reasoning": false,
+      "temperature": 0,
+      "top_p": 0,
+      "presence_penalty": 0,
+      "frequency_penalty": 0,
+      "max_tokens": 0,
+      "max_length": 0
+    },
+    "prompt": {
+      "template": "",
+      "input_vars": null
+    }
+  },
+  "keepalive": "30m",
+  "enabled": true,
+  "chat_settings": {
+    "greeting_message": "I can conduct deep research across web and internal data sources. What topic would you like me to research?",
+    "suggested": {
+      "enabled": false,
+      "questions": []
+    },
+    "input_preprocess_tpl": "",
+    "history_message": {
+      "number": 30,
+      "compression_threshold": 1000,
+      "summary": true
+    }
+  },
+  "builtin": false,
+  "config": {
+    "max_steps": 5,
+    "max_researcher_iterations": 5,
+    "max_concurrent_research_units": 5,
+    "max_results": 5,
+    "timeout": "30m",
+    "research_depth": "basic",
+    "report_format": "markdown",
+    "external_search": {
+      "engine": "duckduckgo"
+    }
+  },
+  "role_prompt": "You are a Deep Research AI assistant.\n\nYour role is to help users conduct comprehensive, multi-step research on complex topics. You gather information from available sources and structure findings into organized reports.\n\nGuidelines:\n- Help users formulate clear, well-scoped research questions\n- If a query is too vague, ask clarifying questions to narrow the scope\n- For simple factual questions that don't need multi-step research, directly answer without triggering the research pipeline\n- Always communicate in the same language as the user's query"
+}

--- a/config/setup/zh-CN/assistant.tpl
+++ b/config/setup/zh-CN/assistant.tpl
@@ -1287,3 +1287,63 @@ POST $[[SETUP_INDEX_PREFIX]]assistant$[[SETUP_SCHEMA_VER]]/$[[SETUP_DOC_TYPE]]/g
      "builtin": true,
      "role_prompt": "你是 Coco AI（https://coco.rs￼）开发的 AI 助手，由 极限科技 / INFINI Labs（https://infinilabs.com￼）的技术团队驱动。"
 }
+
+POST $[[SETUP_INDEX_PREFIX]]assistant$[[SETUP_SCHEMA_VER]]/$[[SETUP_DOC_TYPE]]/deep_research
+{
+  "_system": {
+    "owner_id": "$[[SETUP_OWNER_ID]]"
+  },
+  "id": "deep_research",
+  "created": "2026-06-22T00:00:00.000000+08:00",
+  "updated": "2026-06-22T00:00:00.000000+08:00",
+  "name": "深度研究",
+  "description": "跨网络和企业内部数据源进行全面的多步骤研究，生成结构化报告。",
+  "icon": "font_Search01",
+  "type": "deep_research",
+  "answering_model": {
+    "provider_id": "",
+    "name": "",
+    "settings": {
+      "reasoning": false,
+      "temperature": 0,
+      "top_p": 0,
+      "presence_penalty": 0,
+      "frequency_penalty": 0,
+      "max_tokens": 0,
+      "max_length": 0
+    },
+    "prompt": {
+      "template": "",
+      "input_vars": null
+    }
+  },
+  "keepalive": "30m",
+  "enabled": true,
+  "chat_settings": {
+    "greeting_message": "我可以跨网络和企业数据源进行深度研究。您希望我研究什么话题？",
+    "suggested": {
+      "enabled": false,
+      "questions": []
+    },
+    "input_preprocess_tpl": "",
+    "history_message": {
+      "number": 30,
+      "compression_threshold": 1000,
+      "summary": true
+    }
+  },
+  "builtin": false,
+  "config": {
+    "max_steps": 5,
+    "max_researcher_iterations": 5,
+    "max_concurrent_research_units": 5,
+    "max_results": 5,
+    "timeout": "30m",
+    "research_depth": "basic",
+    "report_format": "markdown",
+    "external_search": {
+      "engine": "duckduckgo"
+    }
+  },
+  "role_prompt": "你是一个深度研究（Deep Research）AI 助手。\n\n你的职责是帮助用户对复杂话题进行全面的、多步骤的深入研究。你可以从多种来源收集信息，并将发现结果整理成结构化的报告。\n\n指引：\n- 帮助用户提出清晰、范围明确的研究问题\n- 如果用户的查询过于宽泛，请通过追问来帮助收窄研究范围\n- 对于不需要多步骤研究的简单事实性问题，直接回答即可，无需触发研究流程\n- 始终使用与用户提问相同的语言进行交流"
+}


### PR DESCRIPTION
Without a pre-seeded assistant of type deep_research, users who upgrade to a version with deep research support cannot use the feature without manually creating an assistant through the UI. This defeats the principle of shipping every new feature with a ready-to-use entry point.

Add template entries for both en-US and zh-CN so that setup/bootstrap creates the assistant automatically and users can start deep research immediately.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation