### PR TITLE
chore: quote keystore secret values in coco.yml to prevent YAML parsing errors

### DIFF
--- a/coco.yml
+++ b/coco.yml
@@ -1,7 +1,7 @@
 env:
   ES_ENDPOINT: https://localhost:9200
   ES_USERNAME: admin
-  ES_PASSWORD: $[[keystore.ES_PASSWORD]]
+  ES_PASSWORD: "$[[keystore.ES_PASSWORD]]"
   WEB_BINDING: 0.0.0.0:9000
   API_BINDING: 0.0.0.0:2900
 
@@ -106,7 +106,7 @@ elasticsearch:
       enabled: false
     basic_auth:
       username: $[[env.ES_USERNAME]]
-      password: $[[env.ES_PASSWORD]]
+      password: "$[[env.ES_PASSWORD]]"
 
 api:
   enabled: true
@@ -134,8 +134,8 @@ web:
         - "www.coco.rs"
       provider:
         tencent_dns:
-          secret_id: $[[keystore.TENCENT_DNS_ID]] #./bin/coco keystore add TENCENT_DNS_ID
-          secret_key: $[[keystore.TENCENT_DNS_KEY]] #./bin/coco keystore add TENCENT_DNS_KEY
+          secret_id: "$[[keystore.TENCENT_DNS_ID]]" #./bin/coco keystore add TENCENT_DNS_ID
+          secret_key: "$[[keystore.TENCENT_DNS_KEY]]" #./bin/coco keystore add TENCENT_DNS_KEY
   security:
     enabled: true
     managed: false #remote managed instance

--- a/tests/assets/coco.yml
+++ b/tests/assets/coco.yml
@@ -1,7 +1,7 @@
 env:
   ES_ENDPOINT: http://localhost:9200
   ES_USERNAME: admin
-  ES_PASSWORD: $[[keystore.ES_PASSWORD]]
+  ES_PASSWORD: "$[[keystore.ES_PASSWORD]]"
   WEB_BINDING: 0.0.0.0:9000
   API_BINDING: 0.0.0.0:2900
 
@@ -260,7 +260,7 @@ elasticsearch:
       enabled: false
     basic_auth:
       username: $[[env.ES_USERNAME]]
-      password: $[[env.ES_PASSWORD]]
+      password: "$[[env.ES_PASSWORD]]"
 
 api:
   enabled: true
@@ -288,8 +288,8 @@ web:
         - "www.coco.rs"
       provider:
         tencent_dns:
-          secret_id: $[[keystore.TENCENT_DNS_ID]] #./bin/coco keystore add TENCENT_DNS_ID
-          secret_key: $[[keystore.TENCENT_DNS_KEY]] #./bin/coco keystore add TENCENT_DNS_KEY
+          secret_id: "$[[keystore.TENCENT_DNS_ID]]" #./bin/coco keystore add TENCENT_DNS_ID
+          secret_key: "$[[keystore.TENCENT_DNS_KEY]]" #./bin/coco keystore add TENCENT_DNS_KEY
   security:
     enabled: true
     managed: false #remote managed instance


### PR DESCRIPTION


## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation