### PR TITLE
refactor: document preview page to handle raw_content streams and external links

### DIFF
--- a/docs/content.en/docs/references/document.md
+++ b/docs/content.en/docs/references/document.md
@@ -208,8 +208,17 @@ curl -H 'Content-Type: application/json' -XDELETE http://localhost:9000/document
 //request
 curl -XGET http://localhost:9000/document/cso9vr3q50k38nobvmcg/raw_content/text
 
-//response
-(Raw document content is returned based on the hint parameter)
+//response when the document stores raw content
+(Raw document content is returned with the appropriate Content-Type)
+
+//response when the document URL points to an external resource
+HTTP/1.1 200 OK
+Content-Type: application/json
+X-Document-Redirect: true
+
+{
+  "url": "https://example.com/path/to/document.pdf"
+}
 ```
 
 | Parameter | Type   | Description                                              |

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -14,6 +14,7 @@ Information about release notes of Coco Server is provided here.
 - fix: principal search filter field for managed mode #696
 - fix: default model provider mismatch in settings #698
 ### ✈️ Improvements
+- refactor: document preview page to handle raw_content streams and external links #699
 - refactor: include document create time in LLM prompt #700
 - chore: correct moonshot base url #701
 

--- a/modules/document/document.go
+++ b/modules/document/document.go
@@ -134,7 +134,7 @@ func (h *APIHandler) getDocRawContent(w http.ResponseWriter, req *http.Request, 
 	}
 
 	// Check if URL is raw content or external URL
-	if obj.Metadata["url_is_raw_content"] == true {
+	if obj.Metadata["raw_content_returns_file"] == true {
 		datasourceID := obj.Source.ID
 		datasource, err := common.GetDatasourceConfig(ctx, datasourceID)
 		if err != nil {
@@ -298,8 +298,14 @@ func (h *APIHandler) getDocRawContent(w http.ResponseWriter, req *http.Request, 
 		http.ServeContent(w, req, fileName, modTime, reader)
 
 	} else {
-		// Redirect to external URL
-		http.Redirect(w, req, obj.URL, http.StatusFound)
+		// The document URL points to an external resource. Instead of issuing a
+		// 302 redirect (which becomes opaque and unreadable cross-origin), return
+		// the target URL as JSON so the caller can decide how to open it.
+		w.Header().Set("X-Document-Redirect", "true")
+		w.Header().Set("Access-Control-Expose-Headers", "X-Document-Redirect")
+		h.WriteJSON(w, util.MapStr{
+			"url": obj.URL,
+		}, http.StatusOK)
 	}
 }
 

--- a/plugins/connectors/local_fs/plugin.go
+++ b/plugins/connectors/local_fs/plugin.go
@@ -196,7 +196,7 @@ func (p *Plugin) saveDocument(ctx *pipeline.Context, currentPath, basePath strin
 	if doc.Metadata == nil {
 		doc.Metadata = make(map[string]interface{})
 	}
-	doc.Metadata["url_is_raw_content"] = true
+	doc.Metadata["raw_content_returns_file"] = true
 
 	doc.ID = util.MD5digest(fmt.Sprintf("%s-%s", datasource.ID, currentPath))
 

--- a/plugins/connectors/s3/plugin.go
+++ b/plugins/connectors/s3/plugin.go
@@ -103,7 +103,7 @@ func (p *Plugin) Fetch(ctx *pipeline.Context, connector *core.Connector, datasou
 			doc.Metadata[k] = v
 		}
 
-		doc.Metadata["url_is_raw_content"] = true
+		doc.Metadata["raw_content_returns_file"] = true
 
 		doc.Owner = &core.UserInfo{
 			UserID:   obj.Owner.ID,

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -7515,7 +7515,6 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
-    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -10610,12 +10609,6 @@ snapshots:
       '@vue/compiler-ssr': 3.5.34
       '@vue/shared': 3.5.34
       vue: 3.5.34(typescript@5.6.3)
-
-  '@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      '@vue/compiler-ssr': 3.5.34
-      '@vue/shared': 3.5.34
-      vue: 3.5.34(typescript@5.9.3)
 
   '@vue/shared@3.5.34': {}
 
@@ -16011,7 +16004,7 @@ snapshots:
       '@vue/compiler-dom': 3.5.34
       '@vue/compiler-sfc': 3.5.34
       '@vue/runtime-dom': 3.5.34
-      '@vue/server-renderer': 3.5.34(vue@3.5.34(typescript@5.9.3))
+      '@vue/server-renderer': 3.5.34(vue@3.5.34(typescript@5.6.3))
       '@vue/shared': 3.5.34
     optionalDependencies:
       typescript: 5.9.3

--- a/web/src/locales/langs/en-us/page.ts
+++ b/web/src/locales/langs/en-us/page.ts
@@ -392,7 +392,7 @@ const page: App.I18n.Schema['translation']['page'] = {
         type: 'Type',
         webhook: 'Webhook',
         enrichment_pipeline: 'Enrichment Pipeline',
-        document_analysis: 'Document Analysis',
+        document_analysis: 'Document Analysis'
       },
       title: '{{connector}} Connection',
       tooltip: {
@@ -530,7 +530,7 @@ const page: App.I18n.Schema['translation']['page'] = {
       createdBy: 'Created By',
       updatedBy: 'Updated By',
       deleteConfirm: 'Are you sure you want to delete this document?',
-      deleteAllConfirm: 'Are you sure you want to delete all selected documents?',
+      deleteAllConfirm: 'Are you sure you want to delete all selected documents?'
     },
     file: {
       title: 'Document Management'
@@ -553,7 +553,7 @@ const page: App.I18n.Schema['translation']['page'] = {
       tipsSettings: 'Configure Now',
       ignoreTips: 'Do not remind again',
       tipsSuccess: 'All default models have been configured. Start experiencing the full AI capabilities.',
-      tipsSuccessButton: 'OK',
+      tipsSuccessButton: 'OK'
     },
     languageModel: {
       title: 'Language Model',
@@ -585,8 +585,10 @@ const page: App.I18n.Schema['translation']['page'] = {
     skipModal: {
       title: 'Skip setup?',
       hints: {
-        desc1: 'No default model is set. If you skip this step, some built-in AI features (e.g., AI Assistant, Document Processing Pipeline) will not function properly until a model is specified.',
-        desc2: 'You can add models later in the "Model Provider" section and set the default model in "System Configuration".',
+        desc1:
+          'No default model is set. If you skip this step, some built-in AI features (e.g., AI Assistant, Document Processing Pipeline) will not function properly until a model is specified.',
+        desc2:
+          'You can add models later in the "Model Provider" section and set the default model in "System Configuration".'
       }
     }
   },
@@ -881,9 +883,11 @@ const page: App.I18n.Schema['translation']['page'] = {
     default_model: {
       labels: {
         default_model: 'Default Model',
-        default_model_desc: 'This configuration will be applied as the default value for AI assistants and document processing pipelines that do not have a separately specified model.',
+        default_model_desc:
+          'This configuration will be applied as the default value for AI assistants and document processing pipelines that do not have a separately specified model.',
         ai_assistant: 'AI Assistant',
-        ai_assistant_desc: 'Specify dedicated models for different stages of the AI assistant to optimize performance and cost. If not configured, the language model from the default model will be used.',
+        ai_assistant_desc:
+          'Specify dedicated models for different stages of the AI assistant to optimize performance and cost. If not configured, the language model from the default model will be used.',
         intent_analysis_model: 'Intent Analysis Model',
         picking_doc_model: 'Picking Doc Model',
         picking_tool_model: 'Picking Tool Model',
@@ -897,9 +901,10 @@ const page: App.I18n.Schema['translation']['page'] = {
         default_pipeline_for_document: 'Data Source Document',
         output_language: 'Output Language',
         processing_pipeline: 'Processing Pipeline',
-        output_language_desc: 'Controls the output language of AI-generated content in the pipeline, including summaries, tags, and analysis results.',
-      }, 
-      title: 'Document Processing',
+        output_language_desc:
+          'Controls the output language of AI-generated content in the pipeline, including summaries, tags, and analysis results.'
+      },
+      title: 'Document Processing'
     },
     setupLater: 'Set Up Later'
   },
@@ -1016,7 +1021,8 @@ const page: App.I18n.Schema['translation']['page'] = {
       openSource: 'Open Source',
       reload: 'Reload',
       continueVisiting: 'Continue Visiting',
-      cancel: 'Cancel'
+      cancel: 'Cancel',
+      download: 'Download'
     },
     hints: {
       failed: 'Sorry, something went wrong',

--- a/web/src/locales/langs/zh-cn/page.ts
+++ b/web/src/locales/langs/zh-cn/page.ts
@@ -570,7 +570,7 @@ const page: App.I18n.Schema['translation']['page'] = {
         type: '数据源类型',
         webhook: '启用 Webhook',
         enrichment_pipeline: 'Enrichment Pipeline',
-        document_analysis: '文档分析',
+        document_analysis: '文档分析'
       },
       title: '连接 {{connector}}',
       tooltip: {
@@ -657,7 +657,7 @@ const page: App.I18n.Schema['translation']['page'] = {
       createdBy: '创建人',
       updatedBy: '更新人',
       deleteConfirm: '您确定要删除此文档吗？',
-      deleteAllConfirm: '您确定要删除所有选中的文档吗？',
+      deleteAllConfirm: '您确定要删除所有选中的文档吗？'
     },
     file: {
       title: '文档管理'
@@ -706,7 +706,7 @@ const page: App.I18n.Schema['translation']['page'] = {
       tipsSettings: '立即配置',
       ignoreTips: '不再提醒',
       tipsSuccess: '默认模型已全部配置完成，开始体验完整 AI 能力',
-      tipsSuccessButton: '好的',
+      tipsSuccessButton: '好的'
     },
     languageModel: {
       title: '语言模型',
@@ -738,8 +738,9 @@ const page: App.I18n.Schema['translation']['page'] = {
     skipModal: {
       title: '确认跳过？',
       hints: {
-        desc1: '当前未设置默认模型。如果跳过此步骤，部分内置 AI 功能（如 AI 助手、文档处理 Pipeline）在未单独指定模型前将无法正常运行。',
-        desc2: '您可以稍后在“模型提供商”中添加模型，并在“系统配置”中设置默认模型。',
+        desc1:
+          '当前未设置默认模型。如果跳过此步骤，部分内置 AI 功能（如 AI 助手、文档处理 Pipeline）在未单独指定模型前将无法正常运行。',
+        desc2: '您可以稍后在“模型提供商”中添加模型，并在“系统配置”中设置默认模型。'
       }
     }
   },
@@ -1011,9 +1012,9 @@ const page: App.I18n.Schema['translation']['page'] = {
         default_pipeline_for_document: '数据源文档处理',
         output_language: '输出语言',
         processing_pipeline: '处理 Pipeline',
-        output_language_desc: '控制 Pipeline 中 AI 生成内容的输出语言，包括摘要、标签与分析结果等。',
-      }, 
-      title: '文档处理',
+        output_language_desc: '控制 Pipeline 中 AI 生成内容的输出语言，包括摘要、标签与分析结果等。'
+      },
+      title: '文档处理'
     },
     setupLater: '稍后设置'
   },
@@ -1172,7 +1173,8 @@ const page: App.I18n.Schema['translation']['page'] = {
       openSource: '打开来源',
       reload: '重新加载',
       continueVisiting: '继续访问',
-      cancel: '取消'
+      cancel: '取消',
+      download: '下载'
     },
     hints: {
       failed: '抱歉，出错了',

--- a/web/src/pages/preview/document/[id].tsx
+++ b/web/src/pages/preview/document/[id].tsx
@@ -1,18 +1,26 @@
-import { ActionButton, DocDetail } from 'ui-search/source';
-import { Button, Result, Spin, Typography } from 'antd';
+import { Button, Result, Spin } from 'antd';
 import { useParams } from 'react-router-dom';
-import { filesize } from 'filesize';
 
-import { getApiBaseUrl, request } from '@/service/request';
+import { request } from '@/service/request';
 import { fetchEntityUser } from '@/service/api/entity';
 import logoLight from '@/assets/imgs/coco-logo-text-light.svg';
 import logoDark from '@/assets/imgs/coco-logo-text-dark.svg';
-import DateTime from '@/components/DateTime';
-import { SquareArrowOutUpRight } from 'lucide-react';
+import { getDarkMode } from '@/store/slice/theme';
+import { useAppSelector } from '@/hooks/business/useStore';
 import classNames from 'classnames';
-import type { ReactNode } from 'react';
 
-const previewContentTypes = ['image', 'video', 'markdown', 'pdf', 'docx', 'pptx'];
+import PreviewContent from './components/PreviewContent';
+
+// Helper function to extract a filename from a Content-Disposition header.
+// Supported forms include:
+//   attachment; filename="example.pdf"
+//   inline; filename="example.pdf"
+function parseFilenameFromContentDisposition(header: string | null, fallback: string): string {
+  if (!header) return fallback;
+  const match = header.match(/filename="([^"]+)"/);
+  if (match?.[1]) return match[1];
+  return fallback;
+}
 
 export function Component() {
   const { id } = useParams();
@@ -21,21 +29,81 @@ export function Component() {
   const appIntegrationId = searchParams.get('app-integration-id');
 
   const embedded = mode === 'embedded';
+  const darkMode = useAppSelector(getDarkMode);
+  const theme = darkMode ? 'dark' : 'light';
 
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<any>();
   const [error, setError] = useState<any>();
-  const [sourceUrl, setSourceUrl] = useState<string>();
+  const [redirectUrl, setRedirectUrl] = useState<string>();
+  const [contentBlobUrl, setContentBlobUrl] = useState<string>();
+  const [downloadFilename, setDownloadFilename] = useState<string>();
+  const [rawContentError, setRawContentError] = useState<string>();
   const { t } = useTranslation();
+
+  // requestHeaders is used by the Preview sub-components when fetching the
+  // raw_content URL. We pass the app-integration-id header so embedded/widget
+  // preview works consistently.
+  const requestHeaders = useMemo(() => {
+    return appIntegrationId ? { 'APP-INTEGRATION-ID': appIntegrationId } : undefined;
+  }, [appIntegrationId]);
+
+  // Inspect the raw_content endpoint to decide whether the document is an
+  // external link or a file stream. The endpoint returns a JSON wrapper with the
+  // external URL for redirects, and a file stream for raw content. We use the
+  // X-Document-Redirect header to distinguish the two without relying on a 302
+  // status, which is opaque and unreadable in cross-origin contexts.
+  const inspectRawContent = async (docData: any) => {
+    const rawContent: string | undefined = docData?.metadata?.raw_content;
+    if (!rawContent) return;
+
+    try {
+      const res = await fetch(rawContent, {
+        headers: requestHeaders
+      });
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+
+      if (res.headers.get('X-Document-Redirect')) {
+        const payload = await res.json();
+        setRedirectUrl(payload.url);
+        return;
+      }
+
+      const blob = await res.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      const filename = parseFilenameFromContentDisposition(
+        res.headers.get('Content-Disposition'),
+        docData.title || 'download'
+      );
+
+      setContentBlobUrl(blobUrl);
+      setDownloadFilename(filename);
+
+      // Overwrite the raw_content URL with the Blob URL. The Preview
+      // sub-components read metadata.raw_content and fetch from it; by giving
+      // them a Blob URL we avoid a second network request and ensure the
+      // rendered content is exactly what raw_content returned.
+      setData((prev: any) => ({
+        ...prev,
+        metadata: {
+          ...prev?.metadata,
+          raw_content: blobUrl
+        }
+      }));
+    } catch (err) {
+      setRawContentError(err instanceof Error ? err.message : String(err));
+    }
+  };
 
   useAsyncEffect(async () => {
     try {
-      const headers = appIntegrationId ? { 'APP-INTEGRATION-ID': appIntegrationId } : undefined;
-
       const { data } = await request({
         method: 'get',
         url: `/document/${id}`,
-        headers
+        headers: requestHeaders
       });
 
       const dataSource = data._source;
@@ -43,23 +111,23 @@ export function Component() {
       let ownerData;
       const ownerId = dataSource?._system?.owner_id;
       if (ownerId) {
-        const { data } = await fetchEntityUser({ id: ownerId }, { headers, ignoreError: true });
+        const { data } = await fetchEntityUser({ id: ownerId }, { headers: requestHeaders, ignoreError: true });
         ownerData = data;
       }
 
-      setData({
+      const enrichedData = {
         ...dataSource,
         owner: ownerData
-      });
+      };
 
-      const contentType = dataSource?.metadata?.content_type;
-      const rawContent = dataSource?.metadata?.raw_content;
-      const hasPreview = !!rawContent && previewContentTypes.includes(contentType);
-      const hasAIInsight = !!dataSource?.ai_insights?.text;
+      setData(enrichedData);
 
-      if (!embedded && !hasPreview && !hasAIInsight && rawContent) {
-        setSourceUrl(rawContent);
-      }
+      // We must inspect the raw_content endpoint before rendering the preview,
+      // because the endpoint returns either a file stream or a JSON wrapper with
+      // the external URL. Replacing metadata.raw_content with a Blob URL is the
+      // cleanest way to let the Preview components render the fetched content
+      // without extra fetch logic.
+      await inspectRawContent(enrichedData);
     } catch (error) {
       if (error instanceof Error) {
         setError(error.message);
@@ -69,81 +137,18 @@ export function Component() {
     } finally {
       setLoading(false);
     }
-  }, [appIntegrationId, embedded, id]);
+  }, [appIntegrationId, embedded, id, requestHeaders]);
 
-  const openTauriUrl = (url: string) => {
-    window.parent.postMessage(
-      {
-        type: 'OPEN_TAURI_URL',
-        payload: { url }
-      },
-      '*'
-    );
-  };
-
-  const renderActionButtons = (): ReactNode[] => {
-    if (embedded) {
-      return [
-        <Button
-          className='size-6!'
-          icon={<SquareArrowOutUpRight className='size-3.5 text-primary' />}
-          key='openSource'
-          onClick={() => {
-            openTauriUrl(data?.metadata?.raw_content);
-          }}
-        />
-      ];
-    }
-
-    return [
-      <ActionButton
-        icon={<SquareArrowOutUpRight />}
-        key='openSource'
-        onClick={() => {
-          setSourceUrl(data?.metadata?.raw_content);
-        }}
-      >
-        {t('page.preview.buttons.openSource')}
-      </ActionButton>
-    ];
-  };
+  // Revoke the Blob URL on unmount to avoid leaking memory.
+  useEffect(() => {
+    return () => {
+      if (contentBlobUrl) {
+        URL.revokeObjectURL(contentBlobUrl);
+      }
+    };
+  }, [contentBlobUrl]);
 
   const renderContent = () => {
-    if (sourceUrl) {
-      const url = sourceUrl.startsWith('http') ? sourceUrl : `${getApiBaseUrl()}${sourceUrl}`;
-      return (
-        <div className='mt-30 flex justify-center'>
-          <div className='w-full min-w-0 border border-border-secondary rounded-lg bg-black/3 px-6 py-10 dark:bg-white/7 md:w-640px'>
-            <div className='font-bold'>{t('page.preview.hints.leave')}</div>
-
-            <div className='mt-1'>{t('page.preview.hints.externalLinkWarning')}</div>
-
-            <Button
-              className='mt-10 min-w-100px'
-              shape='round'
-              size='large'
-              type='primary'
-              onClick={() => {
-                window.open(appIntegrationId ? `${url}?app-integration-id=${appIntegrationId}` : url);
-              }}
-            >
-              {t('page.preview.buttons.continueVisiting')}
-            </Button>
-            <Button
-              className='ml-12px mt-10 min-w-100px border-[#F0F0F0] dark:border-[#303030]'
-              shape='round'
-              size='large'
-              onClick={() => {
-                setSourceUrl(undefined);
-              }}
-            >
-              {t('page.preview.buttons.cancel')}
-            </Button>
-          </div>
-        </div>
-      );
-    }
-
     if (loading) {
       return (
         <Spin
@@ -176,49 +181,48 @@ export function Component() {
       );
     }
 
+    // When raw_content inspection failed but we still have document metadata,
+    // show a non-fatal warning so the user can retry.
+    if (rawContentError && !contentBlobUrl && !redirectUrl) {
+      return (
+        <div className='h-full flex flex-col justify-center'>
+          <Result
+            status='warning'
+            subTitle={rawContentError}
+            title={t('page.preview.hints.failed')}
+            extra={
+              <Button
+                type='primary'
+                onClick={() => {
+                  setRawContentError(undefined);
+                  inspectRawContent(data);
+                }}
+              >
+                {t('page.preview.buttons.reload')}
+              </Button>
+            }
+          />
+        </div>
+      );
+    }
+
     return (
-      <DocDetail
-        actionButtons={renderActionButtons()}
-        data={{
-          ...data,
-          size: filesize(data?.size ?? 0),
-          created: (
-            data?.created ? (
-              <DateTime
-                showTooltip={false}
-                value={data?.created}
-              />
-            ) : null
-          ),
-          updated: (
-            data?.updated ? (
-              <DateTime
-                showTooltip={false}
-                value={data?.updated}
-              />
-            ) : null
-          )
-        }}
-        i18n={{
-          labels: {
-            type: t('page.preview.labels.type'),
-            size: t('page.preview.labels.size'),
-            createdBy: t('page.preview.labels.createdBy'),
-            createdAt: t('page.preview.labels.createdAt'),
-            updatedAt: t('page.preview.labels.updatedAt'),
-            preview: t('page.preview.labels.preview'),
-            aiInterpretation: t('page.preview.labels.aiInterpretation')
-          }
-        }}
+      <PreviewContent
+        contentBlobUrl={contentBlobUrl}
+        data={data}
+        downloadFilename={downloadFilename}
+        redirectUrl={redirectUrl}
+        requestHeaders={requestHeaders}
+        theme={theme}
       />
     );
   };
 
   return (
-    <div className='h-screen bg-container'>
+    <div className='h-screen bg-white dark:bg-black'>
       <div className={classNames('h-full flex flex-col', [embedded ? 'p-6' : 'px-16px max-w-240 m-auto'])}>
         {!embedded && (
-          <div className='h-20 flex items-center justify-between border-b border-border-secondary'>
+          <div className='h-20 flex items-center border-b border-border-secondary'>
             <div className='children:h-10'>
               <img
                 className='dark:hidden'
@@ -230,8 +234,6 @@ export function Component() {
                 src={logoDark}
               />
             </div>
-
-            <span className='text-xl font-bold'>{t('page.preview.title')}</span>
           </div>
         )}
 

--- a/web/src/pages/preview/document/components/PreviewContent.tsx
+++ b/web/src/pages/preview/document/components/PreviewContent.tsx
@@ -1,0 +1,94 @@
+import { ActionButton, Preview } from 'ui-search/source';
+import { Download } from 'lucide-react';
+import { type FC } from 'react';
+
+interface PreviewContentProps {
+  data: any;
+  redirectUrl?: string;
+  contentBlobUrl?: string;
+  downloadFilename?: string;
+  requestHeaders?: Record<string, string>;
+  theme?: 'auto' | 'dark' | 'light';
+}
+
+export const PreviewContent: FC<PreviewContentProps> = (props) => {
+  const { data, redirectUrl, contentBlobUrl, downloadFilename, requestHeaders, theme } = props;
+  const { t } = useTranslation();
+
+  const handleDownload = () => {
+    if (!contentBlobUrl) return;
+
+    const a = document.createElement('a');
+    a.href = contentBlobUrl;
+    a.download = downloadFilename || 'download';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  };
+
+  if (redirectUrl) {
+    return (
+      <div className='h-full flex flex-col items-center justify-center px-4'>
+        <div className='w-[640px] rounded-lg border border-[#EDEDED] bg-[#FAFAFA] p-6 dark:border-[#303030] dark:bg-[#1C1C1C] flex flex-col gap-4'>
+          <div className='text-sm font-bold leading-relaxed text-[#333] dark:text-[#CCC]'>
+            {t('page.preview.hints.leave')}
+          </div>
+
+          <div className='text-sm font-normal leading-relaxed text-[#333] dark:text-[#CCC]'>
+            {t('page.preview.hints.externalLinkWarning')}
+          </div>
+
+          <div className='break-all text-sm text-[#999] dark:text-[#666]'>
+            {redirectUrl}
+          </div>
+
+          <div className='flex justify-start mt-6'>
+            <ActionButton
+              alwaysExpanded
+              className='!px-4'
+              size='large'
+              onClick={() => {
+                window.open(redirectUrl);
+              }}
+            >
+              {t('page.preview.buttons.continueVisiting')}
+            </ActionButton>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='h-full flex flex-col'>
+      <div className='mb-4 shrink-0 flex items-start justify-between gap-4'>
+        <div>
+          <div className='text-xl font-bold'>{data?.title}</div>
+          <div className='text-sm text-[#999] dark:text-[#666]'>
+            {data?.source?.name}
+            {data?.category ? ` / ${data.category}` : ''}
+          </div>
+        </div>
+
+        {contentBlobUrl && (
+          <ActionButton
+            icon={<Download />}
+            onClick={handleDownload}
+          >
+            {t('page.preview.buttons.download')}
+          </ActionButton>
+        )}
+      </div>
+
+      <div className='flex-1 min-h-0 overflow-hidden'>
+        <Preview
+          data={data}
+          requestHeaders={requestHeaders}
+          theme={theme}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PreviewContent;

--- a/web/src/types/api.d.ts
+++ b/web/src/types/api.d.ts
@@ -359,4 +359,5 @@ declare module 'ui-search/source' {
   export const FullscreenModal: any;
   export const DocDetail: any;
   export const ActionButton: any;
+  export const Preview: any;
 }

--- a/web/widgets/ui-search/src/ResultDetail/DocDetail/ActionButton/index.tsx
+++ b/web/widgets/ui-search/src/ResultDetail/DocDetail/ActionButton/index.tsx
@@ -2,16 +2,22 @@ import { Button, type ButtonProps } from "antd";
 import { useState, useMemo, type FC, type MouseEvent } from "react";
 import { motion } from "motion/react";
 
-export type ActionButtonProps = ButtonProps;
+export type ActionButtonProps = ButtonProps & {
+  /**
+   * Always show the label text, regardless of hover state.
+   * By default the label is only shown on touch devices or when hovered.
+   */
+  alwaysExpanded?: boolean;
+};
 
 const canHover = window.matchMedia("(hover: hover)").matches;
 
 const ActionButton: FC<ActionButtonProps> = (props) => {
-  const { icon, children, onMouseOver, onMouseOut, className = '', ...rest } = props;
+  const { icon, children, alwaysExpanded, onMouseOver, onMouseOut, className = '', ...rest } = props;
 
   const [hovered, setHovered] = useState(false);
 
-  const expanded = useMemo(() => !canHover || hovered, [hovered]);
+  const expanded = useMemo(() => alwaysExpanded || !canHover || hovered, [alwaysExpanded, hovered]);
 
   const handleMouseOver = (event: MouseEvent<HTMLButtonElement>) => {
     setHovered(true);
@@ -35,7 +41,9 @@ const ActionButton: FC<ActionButtonProps> = (props) => {
       onMouseOver={handleMouseOver}
       onMouseOut={handleMouseOut}
     >
-      <span className="inline-flex items-center children:size-4">{icon}</span>
+      {icon && (
+        <span className="inline-flex items-center children:size-4">{icon}</span>
+      )}
 
       <motion.span
         className="overflow-hidden"
@@ -43,7 +51,7 @@ const ActionButton: FC<ActionButtonProps> = (props) => {
         animate={{
           width: expanded ? "auto" : 0,
           opacity: Number(expanded),
-          paddingLeft: Number(expanded) * 8,
+          paddingLeft: Number(expanded && icon) * 8,
         }}
       >
         {children}

--- a/web/widgets/ui-search/src/ResultDetail/DocDetail/DocDetail/components/Preview/components/Image/index.tsx
+++ b/web/widgets/ui-search/src/ResultDetail/DocDetail/DocDetail/components/Preview/components/Image/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState, type FC } from "react";
 import { Image as AntdImage, Skeleton } from "antd";
 import { useSize } from "ahooks";
 import { DocDetailProps } from "@/ResultDetail/DocDetail/DocDetail";
+import { isBlobUrl } from "../../utils";
 
 interface ImageProps extends DocDetailProps {
   onLoadingChange?: (loading: boolean) => void;
@@ -18,17 +19,34 @@ const Image: FC<ImageProps> = (props) => {
     const targetUrl = data?.metadata?.raw_content || data?.thumbnail;
     if (!targetUrl) return;
 
+    if (isBlobUrl(targetUrl)) {
+      setImgSrc(targetUrl);
+      onLoadingChange?.(false);
+      return;
+    }
+
     onLoadingChange?.(true);
+    let objectUrl = "";
+
     fetch(targetUrl, { headers: requestHeaders })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.blob();
       })
-      .then((blob) => setImgSrc(URL.createObjectURL(blob)))
+      .then((blob) => {
+        objectUrl = URL.createObjectURL(blob);
+        setImgSrc(objectUrl);
+      })
       .catch((e) => {
         onLoadError?.(e instanceof Error ? e : new Error(String(e)));
       })
       .finally(() => onLoadingChange?.(false));
+
+    return () => {
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    };
   }, [data?.metadata?.raw_content, data?.thumbnail, requestHeaders]);
 
   const calcHeight = useMemo(() => {

--- a/web/widgets/ui-search/src/ResultDetail/DocDetail/DocDetail/components/Preview/components/Pdf/index.tsx
+++ b/web/widgets/ui-search/src/ResultDetail/DocDetail/DocDetail/components/Preview/components/Pdf/index.tsx
@@ -2,6 +2,7 @@ import { Document, Page, pdfjs } from "react-pdf";
 import { useState, useEffect, useRef, type FC } from "react";
 import { Pagination } from "antd";
 import { DocDetailProps } from "@/ResultDetail/DocDetail/DocDetail";
+import { isBlobUrl } from "../../utils";
 import pdfjsWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
 
 pdfjs.GlobalWorkerOptions.workerSrc = pdfjsWorkerUrl;
@@ -29,6 +30,12 @@ const Pdf: FC<PdfProps> = (props) => {
 
     if (url) {
       onLoadingChange?.(true);
+
+      if (isBlobUrl(url)) {
+        setPdfUrl(url);
+        onLoadingChange?.(false);
+        return;
+      }
 
       fetch(url, { headers: requestHeaders })
         .then((res) => {

--- a/web/widgets/ui-search/src/ResultDetail/DocDetail/DocDetail/components/Preview/components/Video/index.tsx
+++ b/web/widgets/ui-search/src/ResultDetail/DocDetail/DocDetail/components/Preview/components/Video/index.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState, type FC } from "react";
 
+import { isBlobUrl } from "../../utils";
+
 interface VideoProps {
   url: string;
   requestHeaders?: Record<string, string>;
@@ -13,22 +15,41 @@ const Video: FC<VideoProps> = (props) => {
   const [src, setSrc] = useState<string>(url);
 
   useEffect(() => {
+    if (!url) return;
+
+    if (isBlobUrl(url)) {
+      setSrc(url);
+      onLoadingChange?.(false);
+      return;
+    }
+
     if (!requestHeaders) {
       setSrc(url);
       return;
     }
 
     onLoadingChange?.(true);
+    let objectUrl = "";
+
     fetch(url, { headers: requestHeaders })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.blob();
       })
-      .then((blob) => setSrc(URL.createObjectURL(blob)))
+      .then((blob) => {
+        objectUrl = URL.createObjectURL(blob);
+        setSrc(objectUrl);
+      })
       .catch((e) => {
         onLoadError?.(e instanceof Error ? e : new Error(String(e)));
       })
       .finally(() => onLoadingChange?.(false));
+
+    return () => {
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    };
   }, [url, requestHeaders]);
 
   return <video src={src} className="w-full" controls />;

--- a/web/widgets/ui-search/src/ResultDetail/DocDetail/DocDetail/components/Preview/utils.ts
+++ b/web/widgets/ui-search/src/ResultDetail/DocDetail/DocDetail/components/Preview/utils.ts
@@ -1,0 +1,3 @@
+export function isBlobUrl(url: string | undefined | null): url is string {
+  return typeof url === "string" && url.startsWith("blob:");
+}

--- a/web/widgets/ui-search/src/ResultDetail/DocDetail/DocDetail/index.tsx
+++ b/web/widgets/ui-search/src/ResultDetail/DocDetail/DocDetail/index.tsx
@@ -1,29 +1,22 @@
-import { Button, Collapse, Typography } from "antd";
-import { ChevronDown, ChevronRight, Dot, Minus, SquareArrowOutUpRight } from "lucide-react";
-import { motion } from "motion/react";
+import { Button, Collapse, Typography } from 'antd';
+import { ChevronDown, ChevronRight, Dot, Minus, SquareArrowOutUpRight } from 'lucide-react';
+import { motion } from 'motion/react';
 
-import { useMemo, useState, type FC, type HTMLAttributes, type ReactNode } from "react";
-import Preview from "./components/Preview";
-import AIInterpretation from "./components/AIInterpretation";
-import { clsx } from "clsx";
-import PreviewIcon from "../../../icons/PreviewIcon";
-import AIInsightIcon from "../../../icons/AIInsightIcon";
-import { AuthImage } from "../../../ResultList/AuthImage";
-import loadingFailedSvg from "../../../icons/file-loading-failed.svg";
+import { type FC, type HTMLAttributes, type ReactNode, useMemo, useState } from 'react';
+import Preview from './components/Preview';
+import AIInterpretation from './components/AIInterpretation';
+import { clsx } from 'clsx';
+import PreviewIcon from '../../../icons/PreviewIcon';
+import AIInsightIcon from '../../../icons/AIInsightIcon';
+import { AuthImage } from '../../../ResultList/AuthImage';
+import loadingFailedSvg from '../../../icons/file-loading-failed.svg';
 
 const { Text } = Typography;
 
-export type MetadataContentType =
-  | "image"
-  | "video"
-  | "markdown"
-  | "pdf"
-  | "docx"
-  | "pptx"
-  | "xlsx";
+export type MetadataContentType = 'docx' | 'image' | 'markdown' | 'pdf' | 'pptx' | 'video' | 'xlsx';
 
 export interface DocDetailProps extends HTMLAttributes<HTMLDivElement> {
-  data: {
+  readonly data: {
     id?: string;
     created?: ReactNode;
     updated?: ReactNode;
@@ -37,6 +30,7 @@ export interface DocDetailProps extends HTMLAttributes<HTMLDivElement> {
       content_type?: MetadataContentType;
       height?: number;
       mime_type?: string;
+      raw_content_returns_file?: boolean;
       users?: null | unknown;
       width?: number;
       raw_content?: string;
@@ -70,7 +64,7 @@ export interface DocDetailProps extends HTMLAttributes<HTMLDivElement> {
       text?: string;
     };
   };
-  i18n?: {
+  readonly i18n?: {
     labels?: {
       type?: string;
       size?: string;
@@ -84,15 +78,14 @@ export interface DocDetailProps extends HTMLAttributes<HTMLDivElement> {
       aiInterpretation?: string;
     };
   };
-  requestHeaders?: Record<string, string>;
-  actionButtons?: ReactNode[];
-  mode?: "embedded" | "standalone";
-  theme?: "light" | "dark" | "auto";
+  readonly requestHeaders?: Record<string, string>;
+  readonly actionButtons?: ReactNode[];
+  readonly mode?: 'embedded' | 'standalone';
+  readonly theme?: 'auto' | 'dark' | 'light';
 }
 
-const DocDetail: FC<DocDetailProps> = (props) => {
-  const { data, i18n, actionButtons, requestHeaders, className, mode, theme, ...rest } =
-    props;
+const DocDetail: FC<DocDetailProps> = props => {
+  const { data, i18n, actionButtons, requestHeaders, className, mode, theme, ...rest } = props;
 
   const [expandMore, setExpandMore] = useState(false);
 
@@ -100,194 +93,232 @@ const DocDetail: FC<DocDetailProps> = (props) => {
 
   const moreInfo = [
     {
-      label: i18n?.labels?.type ?? "Type",
-      value: data?.type,
+      label: i18n?.labels?.type ?? 'Type',
+      value: data?.type
     },
     {
-      label: i18n?.labels?.size ?? "Size",
-      value: data?.size,
+      label: i18n?.labels?.size ?? 'Size',
+      value: data?.size
     },
     {
-      label: i18n?.labels?.createdBy ?? "Created By",
-      value: ownerName,
+      label: i18n?.labels?.createdBy ?? 'Created By',
+      value: ownerName
     },
     {
-      label: i18n?.labels?.createdAt ?? "Created At",
-      value: data?.created,
+      label: i18n?.labels?.createdAt ?? 'Created At',
+      value: data?.created
     },
     {
-      label: i18n?.labels?.updatedAt ?? "Updated At",
-      value: data?.updated,
-    },
+      label: i18n?.labels?.updatedAt ?? 'Updated At',
+      value: data?.updated
+    }
   ];
 
   const contentType = data?.metadata?.content_type;
-  const hasPreviewSource = !!contentType && !!data?.metadata?.raw_content;
-  const isInlinePreview = hasPreviewSource && (contentType === "image" || contentType === "video");
+  const hasPreviewSource = Boolean(contentType) && Boolean(data?.metadata?.raw_content);
+  const isInlinePreview = hasPreviewSource && (contentType === 'image' || contentType === 'video');
   const hasCollapsiblePreview =
-    hasPreviewSource && (contentType === "markdown" || contentType === "pdf" || contentType === "docx" || contentType === "pptx");
+    hasPreviewSource &&
+    (contentType === 'markdown' || contentType === 'pdf' || contentType === 'docx' || contentType === 'pptx');
+  // For file types that we don't have a dedicated renderer for, we can still embed the raw content
+  // in a generic iframe/object preview box. This is useful when the raw_content endpoint returns a
+  // file stream that the browser can render (e.g. text, html, plain documents).
+  // We only show this for real raw content (raw_content_returns_file === true); for external links we
+  // do not display the content because the raw_content endpoint just returns a JSON wrapper.
+  const hasGenericPreview =
+    data?.metadata?.raw_content_returns_file === true &&
+    Boolean(data?.metadata?.raw_content) &&
+    !isInlinePreview &&
+    !hasCollapsiblePreview;
 
   const collapseItems = useMemo(() => {
     const items: { key: string; label: ReactNode | string; children: ReactNode }[] = [];
 
     if (hasCollapsiblePreview) {
       items.push({
-        key: "preview",
+        key: 'preview',
         label: (
-          <div className="inline-flex items-center gap-8px">
-            <PreviewIcon size={16} className="shrink-0 text-[--ant-color-primary]"/>
-            <div className="text-#333 dark:text-#666 text-16px leading-22px">
-              {i18n?.labels?.preview ?? "Preview"}
-            </div>
+          <div className='inline-flex items-center gap-8px'>
+            <PreviewIcon
+              className='shrink-0 text-[--ant-color-primary]'
+              size={16}
+            />
+            <div className='text-16px text-#333 leading-22px dark:text-#666'>{i18n?.labels?.preview ?? 'Preview'}</div>
           </div>
         ),
-        children: <Preview {...props} loadingHeight="h-[calc(100cqh-394px)]"/>,
+        children: (
+          <Preview
+            {...props}
+            loadingHeight='h-[calc(100cqh-394px)]'
+          />
+        )
       });
     }
 
     if (data?.ai_insights?.text) {
       items.push({
-        key: "ai-interpretation",
+        key: 'ai-interpretation',
         label: (
-          <div className="inline-flex items-center gap-8px">
-            <AIInsightIcon size={16} className="shrink-0 text-[--ant-color-primary]"/>
-            <div className="text-#333 dark:text-#666 text-16px leading-22px">
-              {i18n?.labels?.aiInterpretation ?? "AI Interpretation"}
+          <div className='inline-flex items-center gap-8px'>
+            <AIInsightIcon
+              className='shrink-0 text-[--ant-color-primary]'
+              size={16}
+            />
+            <div className='text-16px text-#333 leading-22px dark:text-#666'>
+              {i18n?.labels?.aiInterpretation ?? 'AI Interpretation'}
             </div>
           </div>
         ),
-        children: <AIInterpretation {...props} />,
+        children: <AIInterpretation {...props} />
       });
     }
 
     return items;
   }, [hasCollapsiblePreview, data?.ai_insights?.text, i18n, props]);
 
-  const isContentEmpty = !isInlinePreview && collapseItems.length === 0;
-  const canOpenSource = data?.url?.startsWith("http");
+  const isContentEmpty = !isInlinePreview && collapseItems.length === 0 && !hasGenericPreview;
+  const canOpenSource = data?.url?.startsWith('http');
 
   return (
     <div
-      className={clsx("flex flex-col h-full overflow-hidden @container/detail", className)}
+      className={clsx('flex flex-col h-full overflow-hidden @container/detail', className)}
       {...rest}
     >
-      <div className={clsx("text-20px text-[#1A0CAB] dark:text-[#8AB4F8] break-words", mode === "embedded" ? "pr-24px" : "")}>
+      <div
+        className={clsx(
+          'text-20px text-[#1A0CAB] dark:text-[#8AB4F8] break-words',
+          mode === 'embedded' ? 'pr-24px' : ''
+        )}
+      >
         <AuthImage
-          src={data?.icon}
-          className={"w-20px h-20px inline-block align-middle mr-8px"}
+          className='mr-8px inline-block h-20px w-20px align-middle'
           requestHeaders={requestHeaders}
+          src={data?.icon}
         />
-        <span className="align-middle">{data?.title}</span>
+        <span className='align-middle'>{data?.title}</span>
       </div>
 
-      <div className="flex items-center justify-between my-2">
-        <Text
-          className="inline-flex items-center gap-0.5 text-3 text-[#666] dark:text-white/80"
-        >
-          <div>{data?.source?.name ?? "-"}</div>
-          {
-            data?.category && (
-              <>
-                <ChevronRight className="size-3" />
-                <div>{data?.category}</div>
-              </>
-            )
-          }
-          {
-            ownerName && (
-              <>
-                <Minus className="size-3 rotate-90" />
-                <div>{ownerName}</div>
-              </>
-            )
-          }
-          {
-            data?.updated && (
-              <>
-                <Dot className="size-3" />
-                <div>{data?.updated}</div>
-              </>
-            )
-          }
+      <div className='my-2 flex items-center justify-between'>
+        <Text className='inline-flex items-center gap-0.5 text-3 text-[#666] dark:text-white/80'>
+          <div>{data?.source?.name ?? '-'}</div>
+          {data?.category && (
+            <>
+              <ChevronRight className='size-3' />
+              <div>{data?.category}</div>
+            </>
+          )}
+          {ownerName && (
+            <>
+              <Minus className='size-3 rotate-90' />
+              <div>{ownerName}</div>
+            </>
+          )}
+          {data?.updated && (
+            <>
+              <Dot className='size-3' />
+              <div>{data?.updated}</div>
+            </>
+          )}
 
           <ChevronDown
-            className={clsx(
-              "ml-2 size-3 hover:text-[--ant-color-primary] transition cursor-pointer",
-              {
-                "-scale-y-100": expandMore,
-              }
-            )}
+            className={clsx('ml-2 size-3 hover:text-[--ant-color-primary] transition cursor-pointer', {
+              '-scale-y-100': expandMore
+            })}
             onClick={() => {
-              setExpandMore((prev) => !prev);
+              setExpandMore(prev => !prev);
             }}
           />
         </Text>
 
-        <div className="inline-flex gap-2">{actionButtons}</div>
+        <div className='inline-flex gap-2'>{actionButtons}</div>
       </div>
 
       <motion.div
-        className="bg-black/3 dark:bg-white/4 rounded-lg overflow-hidden"
+        className='overflow-hidden rounded-lg bg-black/3 dark:bg-white/4'
         initial={false}
         animate={{
-          height: expandMore ? "auto" : 0,
+          height: expandMore ? 'auto' : 0,
           opacity: expandMore ? 1 : 0,
-          marginBottom: expandMore ? "1rem" : 0,
+          marginBottom: expandMore ? '1rem' : 0
         }}
       >
-        <div className="flex flex-wrap gap-row-2 p-4">
-          {moreInfo.map((item) => {
+        <div className='flex flex-wrap gap-row-2 p-4'>
+          {moreInfo.map(item => {
             const { label, value } = item;
 
             return (
               <div
+                className='w-1/2 inline-flex items-center <sm:w-full'
                 key={label}
-                className="w-1/2 inline-flex items-center <sm:w-full"
               >
-                <Text type="secondary" className="w-24">
+                <Text
+                  className='w-24'
+                  type='secondary'
+                >
                   {label}
                 </Text>
 
-                <span className="text-3.5">{value ?? "-"}</span>
+                <span className='text-3.5'>{value ?? '-'}</span>
               </div>
             );
           })}
         </div>
       </motion.div>
 
-      <div className="flex flex-col gap-4 flex-1 overflow-auto">
-        {isInlinePreview && <Preview {...props} loadingHeight="aspect-4/3" />}
-        {collapseItems.length > 0 && (
-          <Collapse
-            size="small"
-            defaultActiveKey={[collapseItems[0]?.key]}
-            classNames={{
-              root: "bg-transparent border-[#F0F0F0] dark:border-[#303030] [&_.ant-collapse-panel]:border-[#F0F0F0]! dark:[&_.ant-collapse-panel]:border-[#303030]!",
-              body: "p-24px!",
-              header: "px-16px! py-9px!",
-              title: "flex items-center",
-              icon: "text-[#999]! dark:text-[#666]! [&_.ant-collapse-arrow]:text-16px!"
-            }}
-            items={collapseItems}
-            expandIconPlacement="end"
+      <div className='flex flex-col flex-1 gap-4 overflow-auto'>
+        {isInlinePreview && (
+          <Preview
+            {...props}
+            loadingHeight='aspect-4/3'
           />
         )}
+        {collapseItems.length > 0 && (
+          <Collapse
+            defaultActiveKey={[collapseItems[0]?.key]}
+            expandIconPlacement='end'
+            items={collapseItems}
+            size='small'
+            classNames={{
+              root: 'bg-transparent border-[#F0F0F0] dark:border-[#303030] [&_.ant-collapse-panel]:border-[#F0F0F0]! dark:[&_.ant-collapse-panel]:border-[#303030]!',
+              body: 'p-24px!',
+              header: 'px-16px! py-9px!',
+              title: 'flex items-center',
+              icon: 'text-[#999]! dark:text-[#666]! [&_.ant-collapse-arrow]:text-16px!'
+            }}
+          />
+        )}
+        {hasGenericPreview && (
+          <div className='min-h-360px flex-1 overflow-hidden border border-[#F0F0F0] rounded-lg dark:border-[#303030]'>
+            <iframe
+              className='h-full w-full'
+              sandbox='allow-same-origin'
+              src={data?.metadata?.raw_content}
+              title={data?.title || 'File preview'}
+            />
+          </div>
+        )}
         {isContentEmpty && (
-          <div className="flex flex-1 min-h-360px items-center justify-center px-24px text-center">
-            <div className="flex flex-col items-center">
-              <img className="mb-16px w-80px h-80px" src={loadingFailedSvg} />
-              <div className="text-14px text-[#999] dark:text-[#666] leading-22px">
+          <div className='min-h-360px flex flex-1 items-center justify-center px-24px text-center'>
+            <div className='flex flex-col items-center'>
+              <img
+                className='mb-16px h-80px w-80px'
+                src={loadingFailedSvg}
+              />
+              <div className='text-14px text-[#999] leading-22px dark:text-[#666]'>
                 <div>{i18n?.labels?.previewUnavailableTitle ?? "This file can't be previewed"}</div>
-                <div>{i18n?.labels?.previewUnavailableDescription ?? "The file format may be unsupported or the content is temporarily unavailable"}</div>
+                <div>
+                  {i18n?.labels?.previewUnavailableDescription ??
+                    'The file format may be unsupported or the content is temporarily unavailable'}
+                </div>
               </div>
               {canOpenSource && (
                 <Button
-                  className="mt-24px rounded-20px min-w-120px"
-                  type="primary"
-                  icon={<SquareArrowOutUpRight className="size-14px" />}
+                  className='mt-24px min-w-120px rounded-20px'
+                  icon={<SquareArrowOutUpRight className='size-14px' />}
+                  type='primary'
                   onClick={() => window.open(data.url)}
                 >
-                  {i18n?.labels?.openSource ?? "Open Source"}
+                  {i18n?.labels?.openSource ?? 'Open Source'}
                 </Button>
               )}
             </div>

--- a/web/widgets/ui-search/src/index.tsx
+++ b/web/widgets/ui-search/src/index.tsx
@@ -6,6 +6,7 @@ import { default as Page } from "./FullscreenPage";
 import { default as Modal } from "./FullscreenModal";
 
 export { DocDetail, ActionButton } from "./ResultDetail/DocDetail";
+export { default as Preview } from "./ResultDetail/DocDetail/DocDetail/components/Preview";
 
 import "./index.css";
 import "./styles/css/global.css";


### PR DESCRIPTION
Previously, opening an external link in the preview page required a new tab,
so the APP-INTEGRATION-ID header used for authentication could not be carried
by the browser, causing 401 errors.

This commit introduces a dedicated preview page so that previewing is handled
directly in this page, eliminating the need for a new tab, and thus fixes the
issue.

More implementation details:

The backend raw_content endpoint now returns a 200 JSON response
{"url": "..."} with an X-Document-Redirect header for external URLs, while still
returning file streams when the document stores raw content. The connector field
url_is_raw_content is renamed to raw_content_returns_file to make the intent
clearer. The preview page uses the X-Document-Redirect header to choose between
rendering an embedded file preview with a download button and showing a centered
"continue visiting" panel for external links. Preview sub-components now detect
Blob URLs so they do not re-fetch content that has already been loaded. The
shared DocDetail component only shows the generic iframe preview for real raw
content, preventing the search-result popup from displaying the raw_content
JSON wrapper for external links.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation