### PR TITLE
refactor: include document creation time in LLM prompts and unify reference formatting

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -14,6 +14,7 @@ Information about release notes of Coco Server is provided here.
 - fix: principal search filter field for managed mode #696
 - fix: default model provider mismatch in settings #698
 ### ✈️ Improvements
+- refactor: include document create time in LLM prompt #700
 - chore: correct moonshot base url #701
 
 ## 0.11.0 (2026-06-23)

--- a/modules/assistant/deep_search/init.go
+++ b/modules/assistant/deep_search/init.go
@@ -101,7 +101,7 @@ func RunDeepSearchTask(ctx context.Context, userID string, params *common2.RAGCo
 		if !(cfg.DeepThinkConfig.PickDatasource && !queryIntent.NeedNetworkSearch) {
 			var fetchSize = 50
 			docs, _ := tools.InitialDocumentBriefSearch(ctx, userID, reqMsg, replyMsg, params, 0, fetchSize, sender)
-			params.InputValues["references"] = util.MustToJSON(docs)
+			params.InputValues["references"] = tools.FormatDocumentForReplyReferences(docs)
 
 			if len(docs) > 10 {
 				//re-pick top docs

--- a/modules/assistant/tools/fetch_documents.go
+++ b/modules/assistant/tools/fetch_documents.go
@@ -32,7 +32,7 @@ func FetchDocumentInDepth(ctx context.Context, reqMsg, replyMsg *core.ChatMessag
 		detail := core.ProcessingDetails{Order: 40, Type: common.DeepRead, Description: strBuilder.String()}
 		replyMsg.Details = append(replyMsg.Details, detail)
 
-		inputValues["references"] = formatDocumentForReplyReferences(pickedFullDoc)
+		inputValues["references"] = FormatDocumentForReplyReferences(pickedFullDoc)
 	}
 	return nil
 }

--- a/modules/assistant/tools/internal_search.go
+++ b/modules/assistant/tools/internal_search.go
@@ -119,18 +119,19 @@ func GetTeamsIDByUserID(ctx context.Context, userID string) []string {
 	return []string{}
 }
 
-func formatDocumentForReplyReferences(docs []core.Document) string {
+func FormatDocumentForReplyReferences(docs []core.Document) string {
 	var sb strings.Builder
 	sb.WriteString("<REFERENCES>\n")
 	for i, doc := range docs {
-		sb.WriteString(fmt.Sprintf("<Doc>"))
+		sb.WriteString("<Doc>")
 		sb.WriteString(fmt.Sprintf("ID #%d - %v\n", i+1, doc.ID))
 		sb.WriteString(fmt.Sprintf("Title: %s\n", doc.Title))
 		sb.WriteString(fmt.Sprintf("Source: %s\n", doc.Source))
+		sb.WriteString(fmt.Sprintf("Created: %s\n", doc.Created))
 		sb.WriteString(fmt.Sprintf("Updated: %s\n", doc.Updated))
 		sb.WriteString(fmt.Sprintf("Category: %s\n", doc.GetAllCategories()))
 		sb.WriteString(fmt.Sprintf("Content: %s\n", doc.Content))
-		sb.WriteString(fmt.Sprintf("</Doc>\n"))
+		sb.WriteString("</Doc>\n")
 
 	}
 	sb.WriteString("</REFERENCES>")
@@ -161,6 +162,7 @@ func formatDocumentForPick(docs []core.Document) []util.MapStr {
 		item := util.MapStr{}
 		item["id"] = doc.ID
 		item["title"] = doc.Title
+		item["created"] = doc.Created
 		item["updated"] = doc.Updated
 		item["category"] = doc.Category
 		item["summary"] = util.SubString(doc.Summary, 0, 500)


### PR DESCRIPTION
Time-related questions (e.g., "latest Easysearch release") are easier to answer when the LLM can see when each document was created. Previously, the creation timestamp was missing from the document context shown to the model.

Also, the initial document search in deep search and the later document fetching step formatted documents differently for the LLM: initial search passed raw JSON from the document objects, while fetching used a hand-rolled <REFERENCES> block.

This commit adds the Created field to both the reply reference text and the pick-list JSON, exports FormatDocumentForReplyReferences, and makes the deep search initial search use the same formatter as the document fetch step, so both stages present documents consistently to the LLM.


## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation